### PR TITLE
[card] Tap to Start/Restart & HA service wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm ci
   - `timer.finished` triggers a five-second overlay before settling back to Idle.
 - When Home Assistant omits `remaining`, the card derives an estimated value using `duration` and `last_changed`, and surfaces a notice if drift exceeds ~2 seconds.
 - The card never interpolates or counts down client-side; Home Assistant remains the source of truth for countdown values.
+- Taps on the card body proxy to Home Assistant services: idle taps call `timer.start` with the normalized dial duration, and running taps issue `timer.cancel` followed by `timer.start` to guarantee a clean restart event stream. The UI shows a pending overlay (“Starting…” / “Restarting…”) and ignores further taps until Home Assistant reports the updated state.
 
 ### Dial duration configuration
 
@@ -91,6 +92,7 @@ To experiment locally, run `npm run dev` and open the playground at http://local
    minDurationSeconds: 30
    maxDurationSeconds: 900
    stepSeconds: 10
+   confirmRestart: true # optional—require confirmation before restarting a running timer
    ```
 
 ### Documentation
@@ -163,7 +165,7 @@ Below is a crisp, implementation‑ready specification for a **Tea Timer Card** 
    9.4. `default_preset` (optional index or label).
    9.5. `minDurationSeconds`, `maxDurationSeconds`, `stepSeconds` (optional, with MVD defaults).
    9.6. `finished_auto_idle_ms` (default 5000).
-   9.7. `confirm_restart` (default false).
+   9.7. `confirmRestart` (default false).
 
 10. **Accessibility & Internationalization**
     10.1. Full keyboard support: focusable chips; Space/Enter to start/restart; arrow keys to nudge dial when idle (+/‑ step).

--- a/src/card/TeaTimerCard.test.ts
+++ b/src/card/TeaTimerCard.test.ts
@@ -1,7 +1,18 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TeaTimerCard } from "./TeaTimerCard";
 import type { TimerViewState } from "../state/TimerStateMachine";
 import { formatDurationSeconds } from "../model/duration";
+import type { HomeAssistant } from "../types/home-assistant";
+import { restartTimer, startTimer } from "../ha/services/timer";
+
+vi.mock("../ha/services/timer", () => ({
+  startTimer: vi.fn(),
+  restartTimer: vi.fn(),
+}));
+
+type MockedFn = ReturnType<typeof vi.fn>;
+
+const startTimerMock = startTimer as unknown as MockedFn;
 
 describe("TeaTimerCard", () => {
   const tagName = "tea-timer-card";
@@ -31,6 +42,23 @@ describe("TeaTimerCard", () => {
     };
     handler._onDialInput(new CustomEvent("dial-input", { detail: { value } }));
   }
+
+  function invokePrimaryAction(card: TeaTimerCard) {
+    const handler = card as unknown as { _handlePrimaryAction(): void };
+    handler._handlePrimaryAction();
+  }
+
+  function createHass(): HomeAssistant {
+    return {
+      locale: { language: "en" },
+      states: {},
+      callService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HomeAssistant;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   afterEach(() => {
     document.querySelectorAll(tagName).forEach((el) => el.remove());
@@ -109,5 +137,221 @@ describe("TeaTimerCard", () => {
 
     const display = (card as unknown as { _displayDurationSeconds?: number })._displayDurationSeconds;
     expect(display).toBe(180);
+  });
+
+  it("starts the timer when tapping the card from idle", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
+    card.hass = createHass();
+
+    const idleState: TimerViewState = {
+      status: "idle",
+      durationSeconds: 180,
+      remainingSeconds: 180,
+    };
+
+    setTimerState(card, idleState);
+
+    invokePrimaryAction(card);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(startTimer).toHaveBeenCalledWith(card.hass, "timer.kettle", 180);
+    const internals = card as unknown as { _viewModel?: { ui: { pendingAction: string } } };
+    expect(internals._viewModel?.ui.pendingAction).toBe("start");
+  });
+
+  it("restarts the timer when tapping while running", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
+    card.hass = createHass();
+
+    const runningState: TimerViewState = {
+      status: "running",
+      durationSeconds: 240,
+      remainingSeconds: 120,
+    };
+
+    setTimerState(card, runningState);
+
+    invokePrimaryAction(card);
+
+    await Promise.resolve();
+
+    expect(restartTimer).toHaveBeenCalledWith(card.hass, "timer.kettle", 240);
+    const internals = card as unknown as { _viewModel?: { ui: { pendingAction: string } } };
+    expect(internals._viewModel?.ui.pendingAction).toBe("restart");
+  });
+
+  it("requires confirmation before restarting when confirmRestart is true", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle", confirmRestart: true });
+    card.hass = createHass();
+
+    const runningState: TimerViewState = {
+      status: "running",
+      durationSeconds: 120,
+      remainingSeconds: 60,
+    };
+
+    setTimerState(card, runningState);
+
+    invokePrimaryAction(card);
+
+    const internals = card as unknown as {
+      _confirmRestartVisible: boolean;
+      _onConfirmRestart(): void;
+    };
+
+    expect(restartTimer).not.toHaveBeenCalled();
+    expect(internals._confirmRestartVisible).toBe(true);
+
+    internals._onConfirmRestart();
+
+    await Promise.resolve();
+
+    expect(restartTimer).toHaveBeenCalledWith(card.hass, "timer.kettle", 120);
+  });
+
+  it("ignores repeated taps while an action is pending", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
+    card.hass = createHass();
+
+    const idleState: TimerViewState = {
+      status: "idle",
+      durationSeconds: 200,
+      remainingSeconds: 200,
+    };
+
+    setTimerState(card, idleState);
+
+    let resolveStart: () => void = () => {};
+    const startPromise = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    startTimerMock.mockReturnValueOnce(startPromise);
+
+    invokePrimaryAction(card);
+    invokePrimaryAction(card);
+
+    expect(startTimer).toHaveBeenCalledTimes(1);
+    resolveStart();
+    await startPromise;
+  });
+
+  it("shows an error toast when the service call fails", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
+    card.hass = createHass();
+
+    const idleState: TimerViewState = {
+      status: "idle",
+      durationSeconds: 90,
+      remainingSeconds: 90,
+    };
+
+    setTimerState(card, idleState);
+
+    startTimerMock.mockRejectedValueOnce(new Error("boom"));
+
+    invokePrimaryAction(card);
+
+    const startCall = startTimerMock.mock.results[0]?.value as Promise<unknown> | undefined;
+    if (startCall) {
+      await startCall.catch(() => undefined);
+    }
+
+    await Promise.resolve();
+
+    const internals = card as unknown as {
+      _viewModel?: { ui: { pendingAction: string; error?: { message: string } } };
+    };
+    expect(internals._viewModel?.ui.pendingAction).toBe("none");
+    expect(internals._viewModel?.ui.error?.message).toContain("Couldn't start the timer");
+  });
+
+  it("announces entity unavailable when tapped", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
+    card.hass = createHass();
+
+    const unavailable: TimerViewState = {
+      status: "unavailable",
+    };
+
+    setTimerState(card, unavailable);
+
+    invokePrimaryAction(card);
+
+    await Promise.resolve();
+
+    expect(startTimer).not.toHaveBeenCalled();
+    expect(restartTimer).not.toHaveBeenCalled();
+    const internals = card as unknown as {
+      _viewModel?: { ui: { error?: { message: string } } };
+    };
+    expect(internals._viewModel?.ui.error?.message).toContain("unavailable");
+  });
+
+  it("clamps the duration before calling Home Assistant", async () => {
+    const card = createCard();
+    card.setConfig({
+      type: "custom:tea-timer-card",
+      entity: "timer.kettle",
+      minDurationSeconds: 60,
+      maxDurationSeconds: 600,
+      stepSeconds: 15,
+    });
+    card.hass = createHass();
+
+    const idleState: TimerViewState = {
+      status: "idle",
+      durationSeconds: 120,
+      remainingSeconds: 120,
+    };
+
+    setTimerState(card, idleState);
+
+    triggerDialInput(card, 183);
+
+    invokePrimaryAction(card);
+
+    await Promise.resolve();
+
+    expect(startTimer).toHaveBeenCalledWith(card.hass, "timer.kettle", 180);
+  });
+
+  it("clears the pending action when Home Assistant reports running", async () => {
+    const card = createCard();
+    card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
+    card.hass = createHass();
+
+    const idleState: TimerViewState = {
+      status: "idle",
+      durationSeconds: 150,
+      remainingSeconds: 150,
+    };
+
+    setTimerState(card, idleState);
+
+    invokePrimaryAction(card);
+
+    await Promise.resolve();
+
+    const internalsBefore = card as unknown as { _viewModel?: { ui: { pendingAction: string } } };
+    expect(internalsBefore._viewModel?.ui.pendingAction).toBe("start");
+
+    const runningState: TimerViewState = {
+      status: "running",
+      durationSeconds: 150,
+      remainingSeconds: 150,
+    };
+
+    setTimerState(card, runningState);
+
+    const internalsAfter = card as unknown as { _viewModel?: { ui: { pendingAction: string } } };
+    expect(internalsAfter._viewModel?.ui.pendingAction).toBe("none");
   });
 });

--- a/src/card/TeaTimerCard.ts
+++ b/src/card/TeaTimerCard.ts
@@ -4,7 +4,11 @@ import { baseStyles } from "../styles/base";
 import { cardStyles } from "../styles/card";
 import { parseTeaTimerConfig, TeaTimerConfig } from "../model/config";
 import {
+  clearPendingAction,
   createTeaTimerViewModel,
+  PendingTimerAction,
+  setPendingAction,
+  setViewModelError,
   TeaTimerViewModel,
   updateDialSelection,
 } from "../view/TeaTimerViewModel";
@@ -12,9 +16,10 @@ import { STRINGS } from "../strings";
 import type { HomeAssistant, LovelaceCard } from "../types/home-assistant";
 import { TimerStateController } from "../state/TimerStateController";
 import type { TimerViewState, TimerStatus } from "../state/TimerStateMachine";
-import { formatDurationSeconds } from "../model/duration";
+import { formatDurationSeconds, normalizeDurationSeconds } from "../model/duration";
 import "../dial/TeaTimerDial";
 import type { TeaTimerDial } from "../dial/TeaTimerDial";
+import { restartTimer, startTimer } from "../ha/services/timer";
 
 export class TeaTimerCard extends LitElement implements LovelaceCard {
   static styles = [baseStyles, cardStyles];
@@ -54,6 +59,9 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
   @state()
   private _displayDurationSeconds?: number;
 
+  @state()
+  private _confirmRestartVisible = false;
+
   @query("tea-timer-dial")
   private _dialElement?: TeaTimerDial;
 
@@ -67,6 +75,8 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
 
   private _cachedDialPrimaryLabel?: HTMLElement;
   private _awaitingDialElementSync = false;
+  private _errorTimer?: number;
+  private _confirmRestartDuration?: number;
 
   constructor() {
     super();
@@ -84,6 +94,9 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
     const result = parseTeaTimerConfig(config);
     this._errors = result.errors;
     this._config = result.config ?? undefined;
+    this._confirmRestartVisible = false;
+    this._confirmRestartDuration = undefined;
+    this._clearErrorTimer();
     const state = this._timerStateController.state;
     if (this._config) {
       this._viewModel = createTeaTimerViewModel(this._config, state);
@@ -102,9 +115,15 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
   }
 
   protected render() {
+    const pendingAction = this._viewModel?.ui.pendingAction ?? "none";
     return html`
       ${this._renderErrors()}
-      <section class="card" data-instance-id=${this._config?.cardInstanceId ?? "unconfigured"}>
+      <section
+        class="card"
+        data-instance-id=${this._config?.cardInstanceId ?? "unconfigured"}
+        aria-busy=${pendingAction !== "none" ? "true" : "false"}
+        @click=${this._onCardClick}
+      >
         ${this._renderHeader()}
         ${this._renderStatusPill()}
         ${this._renderDial()}
@@ -114,6 +133,9 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
         <a class="help" href=${STRINGS.gettingStartedUrl} target="_blank" rel="noreferrer">
           ${STRINGS.gettingStartedLabel}
         </a>
+        ${this._renderPendingOverlay()}
+        ${this._confirmRestartVisible ? this._renderRestartConfirm() : nothing}
+        ${this._renderToast()}
       </section>
     `;
   }
@@ -202,10 +224,269 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
     `;
   }
 
+  private _renderPendingOverlay() {
+    const action = this._viewModel?.ui.pendingAction ?? "none";
+    if (action === "none") {
+      return nothing;
+    }
+
+    const label = action === "start" ? STRINGS.pendingStartLabel : STRINGS.pendingRestartLabel;
+    return html`
+      <div class="action-overlay" role="status" aria-live="polite">
+        <span class="spinner" aria-hidden="true"></span>
+        <span>${label}</span>
+      </div>
+    `;
+  }
+
+  private _renderRestartConfirm() {
+    const durationSeconds = this._confirmRestartDuration ?? this._getActionDuration();
+    const durationLabel = formatDurationSeconds(durationSeconds);
+    const message = STRINGS.restartConfirmMessage(durationLabel);
+    return html`
+      <div
+        class="confirm-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-label=${message}
+        @click=${this._onConfirmOverlayClick}
+      >
+        <div class="confirm-surface" role="document" @click=${this._stopPropagation}>
+          <p class="confirm-message">${message}</p>
+          <div class="confirm-actions">
+            <button type="button" class="confirm-primary" @click=${this._onConfirmRestart}>
+              ${STRINGS.restartConfirmConfirm}
+            </button>
+            <button type="button" class="confirm-secondary" @click=${this._onCancelRestart}>
+              ${STRINGS.restartConfirmCancel}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderToast() {
+    const error = this._viewModel?.ui.error;
+    if (!error?.message) {
+      return nothing;
+    }
+
+    const tone = error.code === "entity-unavailable" ? "info" : "error";
+    return html`
+      <div class="toast toast-${tone}" role="status" aria-live="polite">
+        ${error.message}
+      </div>
+    `;
+  }
+
   private _renderStatusPill() {
     const state = this._timerState ?? this._timerStateController.state;
     const label = this._getStatusLabel(state.status);
     return html`<span class="status-pill status-${state.status}" aria-hidden="true">${label}</span>`;
+  }
+
+  private readonly _onCardClick = (event: MouseEvent) => {
+    if (event.defaultPrevented || this._confirmRestartVisible) {
+      return;
+    }
+
+    if (this._shouldIgnoreCardClick(event)) {
+      return;
+    }
+
+    this._handlePrimaryAction();
+  };
+
+  private _shouldIgnoreCardClick(event: MouseEvent): boolean {
+    const path = event.composedPath();
+    for (const node of path) {
+      if (!(node instanceof HTMLElement)) {
+        continue;
+      }
+
+      if (node === this) {
+        break;
+      }
+
+      const tagName = node.tagName.toLowerCase();
+      if (tagName === "a" || tagName === "button") {
+        return true;
+      }
+
+      const role = node.getAttribute("role");
+      if (role === "button") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private _handlePrimaryAction(): void {
+    if (!this._viewModel || !this._config?.entity) {
+      return;
+    }
+
+    if (!this._hass) {
+      return;
+    }
+
+    if (this._viewModel.ui.pendingAction !== "none") {
+      return;
+    }
+
+    const state = this._timerState ?? this._timerStateController.state;
+
+    if (state.status === "unavailable") {
+      this._showEntityUnavailableToast();
+      return;
+    }
+
+    const durationSeconds = this._getActionDuration();
+
+    if (state.status === "running") {
+      if (this._viewModel.ui.confirmRestart) {
+        this._confirmRestartDuration = durationSeconds;
+        this._confirmRestartVisible = true;
+        return;
+      }
+
+      void this._restartTimerAction(durationSeconds);
+      return;
+    }
+
+    void this._startTimerAction(durationSeconds);
+  }
+
+  private _getActionDuration(): number {
+    if (!this._viewModel || !this._config) {
+      return 0;
+    }
+
+    const selected = this._viewModel.selectedDurationSeconds ?? this._viewModel.dial.selectedDurationSeconds;
+    return normalizeDurationSeconds(selected, this._config.dialBounds);
+  }
+
+  private async _startTimerAction(durationSeconds: number): Promise<void> {
+    if (!this._viewModel || !this._config?.entity || !this._hass) {
+      return;
+    }
+
+    if (this._viewModel.ui.pendingAction !== "none") {
+      return;
+    }
+
+    this._viewModel = setViewModelError(this._viewModel, undefined);
+    this._clearErrorTimer();
+    this._viewModel = setPendingAction(this._viewModel, "start", Date.now());
+    this._announceAction("start", durationSeconds);
+
+    try {
+      await startTimer(this._hass, this._config.entity, durationSeconds);
+    } catch {
+      this._viewModel = clearPendingAction(this._viewModel);
+      this._viewModel = setViewModelError(this._viewModel, {
+        message: STRINGS.toastStartFailed,
+        code: "start-failed",
+      });
+      this._scheduleErrorClear();
+    }
+  }
+
+  private async _restartTimerAction(durationSeconds: number): Promise<void> {
+    if (!this._viewModel || !this._config?.entity || !this._hass) {
+      return;
+    }
+
+    if (this._viewModel.ui.pendingAction !== "none") {
+      return;
+    }
+
+    this._confirmRestartVisible = false;
+    this._confirmRestartDuration = undefined;
+    this._viewModel = setViewModelError(this._viewModel, undefined);
+    this._clearErrorTimer();
+    this._viewModel = setPendingAction(this._viewModel, "restart", Date.now());
+    this._announceAction("restart", durationSeconds);
+
+    try {
+      await restartTimer(this._hass, this._config.entity, durationSeconds);
+    } catch {
+      this._viewModel = clearPendingAction(this._viewModel);
+      this._viewModel = setViewModelError(this._viewModel, {
+        message: STRINGS.toastRestartFailed,
+        code: "restart-failed",
+      });
+      this._scheduleErrorClear();
+    }
+  }
+
+  private _announceAction(action: PendingTimerAction, durationSeconds: number): void {
+    const durationLabel = formatDurationSeconds(durationSeconds);
+    if (action === "start") {
+      this._ariaAnnouncement = STRINGS.ariaStarting(durationLabel);
+    } else if (action === "restart") {
+      this._ariaAnnouncement = STRINGS.ariaRestarting(durationLabel);
+    }
+  }
+
+  private _showEntityUnavailableToast(): void {
+    if (!this._viewModel || !this._config?.entity) {
+      return;
+    }
+
+    this._viewModel = setViewModelError(this._viewModel, {
+      message: STRINGS.toastEntityUnavailable(this._config.entity),
+      code: "entity-unavailable",
+    });
+    this._scheduleErrorClear();
+  }
+
+  private readonly _onConfirmOverlayClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    if (event.target === event.currentTarget) {
+      this._onCancelRestart();
+    }
+  };
+
+  private readonly _stopPropagation = (event: Event) => {
+    event.stopPropagation();
+  };
+
+  private readonly _onConfirmRestart = () => {
+    if (this._confirmRestartDuration === undefined) {
+      this._confirmRestartVisible = false;
+      return;
+    }
+
+    void this._restartTimerAction(this._confirmRestartDuration);
+  };
+
+  private readonly _onCancelRestart = () => {
+    this._confirmRestartVisible = false;
+    this._confirmRestartDuration = undefined;
+  };
+
+  private _scheduleErrorClear(): void {
+    this._clearErrorTimer();
+    if (!this._viewModel?.ui.error) {
+      return;
+    }
+
+    this._errorTimer = window.setTimeout(() => {
+      if (this._viewModel) {
+        this._viewModel = setViewModelError(this._viewModel, undefined);
+      }
+      this._errorTimer = undefined;
+    }, 4000);
+  }
+
+  private _clearErrorTimer(): void {
+    if (this._errorTimer !== undefined) {
+      clearTimeout(this._errorTimer);
+      this._errorTimer = undefined;
+    }
   }
 
   private _getPrimaryDialLabel(state: TimerViewState, displaySeconds?: number): string {
@@ -300,13 +581,39 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
 
   private _handleTimerStateChanged(state: TimerViewState) {
     const previousState = this._previousTimerState;
+    const previousViewModel = this._viewModel;
+    if (this._confirmRestartVisible && state.status !== "running") {
+      this._confirmRestartVisible = false;
+      this._confirmRestartDuration = undefined;
+    }
     this._timerState = state;
     if (this._config) {
       this._viewModel = createTeaTimerViewModel(this._config, state, {
         previousState,
-        previousViewModel: this._viewModel,
+        previousViewModel,
       });
     }
+
+    if (this._viewModel) {
+      const pending = previousViewModel?.ui.pendingAction ?? "none";
+      if (pending !== "none") {
+        if (
+          state.status === "running" ||
+          state.status === "unavailable" ||
+          state.status === "finished"
+        ) {
+          this._viewModel = clearPendingAction(this._viewModel);
+        } else if (state.status === "idle" && previousState?.status === "running") {
+          this._viewModel = clearPendingAction(this._viewModel);
+        }
+      }
+
+      if (previousViewModel?.ui.error) {
+        this._viewModel = setViewModelError(this._viewModel, undefined);
+        this._clearErrorTimer();
+      }
+    }
+
     this._handleAriaAnnouncement(state);
     this._previousTimerState = state;
     this._syncDisplayDuration(state);
@@ -345,6 +652,7 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
   public disconnectedCallback(): void {
     super.disconnectedCallback();
     this._clearDialTooltipTimer();
+    this._clearErrorTimer();
   }
 
   private _syncDisplayDuration(state: TimerViewState) {

--- a/src/ha/services/timer.test.ts
+++ b/src/ha/services/timer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { restartTimer, startTimer } from "./timer";
+import type { HomeAssistant } from "../../types/home-assistant";
+
+describe("timer services", () => {
+  it("calls timer.start with seconds", async () => {
+    const callService = vi.fn().mockResolvedValue(undefined);
+    const hass: HomeAssistant = {
+      locale: { language: "en" },
+      states: {},
+      callService,
+    };
+
+    await startTimer(hass, "timer.test", 180);
+
+    expect(callService).toHaveBeenCalledWith("timer", "start", {
+      entity_id: "timer.test",
+      duration: 180,
+    });
+  });
+
+  it("cancels then restarts the timer", async () => {
+    const callService = vi.fn().mockResolvedValue(undefined);
+    const hass: HomeAssistant = {
+      locale: { language: "en" },
+      states: {},
+      callService,
+    };
+
+    await restartTimer(hass, "timer.kitchen", 90);
+
+    expect(callService).toHaveBeenNthCalledWith(1, "timer", "cancel", {
+      entity_id: "timer.kitchen",
+    });
+    expect(callService).toHaveBeenNthCalledWith(2, "timer", "start", {
+      entity_id: "timer.kitchen",
+      duration: 90,
+    });
+  });
+});

--- a/src/ha/services/timer.ts
+++ b/src/ha/services/timer.ts
@@ -1,0 +1,24 @@
+import type { HomeAssistant } from "../../types/home-assistant";
+
+export async function startTimer(
+  hass: HomeAssistant,
+  entityId: string,
+  durationSeconds: number,
+): Promise<void> {
+  await hass.callService("timer", "start", {
+    entity_id: entityId,
+    duration: durationSeconds,
+  });
+}
+
+export async function restartTimer(
+  hass: HomeAssistant,
+  entityId: string,
+  durationSeconds: number,
+): Promise<void> {
+  await hass.callService("timer", "cancel", { entity_id: entityId });
+  await hass.callService("timer", "start", {
+    entity_id: entityId,
+    duration: durationSeconds,
+  });
+}

--- a/src/model/config.test.ts
+++ b/src/model/config.test.ts
@@ -26,6 +26,7 @@ describe("parseTeaTimerConfig", () => {
     expect(result.config?.presets).toHaveLength(2);
     expect(result.config?.entity).toBe("timer.kitchen");
     expect(result.config?.dialBounds).toEqual({ min: 30, max: 600, step: 15 });
+    expect(result.config?.confirmRestart).toBe(false);
   });
 
   it("limits presets to 8 items", () => {
@@ -47,6 +48,17 @@ describe("parseTeaTimerConfig", () => {
     });
 
     expect(result.errors).toContain('The "defaultPreset" option is reserved for a future release.');
+  });
+
+  it("parses confirmRestart flag", () => {
+    const result = parseTeaTimerConfig({
+      entity: "timer.test",
+      presets: [],
+      confirmRestart: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.config?.confirmRestart).toBe(true);
   });
 
   it("validates dial bounds", () => {

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -27,6 +27,7 @@ export interface TeaTimerConfig {
   presets: TeaTimerPresetDefinition[];
   cardInstanceId: string;
   dialBounds: DurationBounds;
+  confirmRestart: boolean;
 }
 
 export interface ParsedTeaTimerConfig {
@@ -34,11 +35,7 @@ export interface ParsedTeaTimerConfig {
   errors: string[];
 }
 
-const RESERVED_OPTIONS = new Set([
-  "defaultPreset",
-  "confirmRestart",
-  "finishedAutoIdleMs",
-]);
+const RESERVED_OPTIONS = new Set(["defaultPreset", "finishedAutoIdleMs"]);
 
 const DEFAULT_MIN_DURATION_SECONDS = 15;
 const DEFAULT_MAX_DURATION_SECONDS = 1200;
@@ -159,6 +156,8 @@ export function parseTeaTimerConfig(input: unknown): ParsedTeaTimerConfig {
     step: Math.max(1, stepSeconds),
   };
 
+  const confirmRestart = typeof raw.confirmRestart === "boolean" ? raw.confirmRestart : false;
+
   const config: TeaTimerConfig = {
     type,
     title,
@@ -166,6 +165,7 @@ export function parseTeaTimerConfig(input: unknown): ParsedTeaTimerConfig {
     presets,
     cardInstanceId: createCardInstanceId(),
     dialBounds,
+    confirmRestart,
   };
 
   return { config, errors };

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -20,6 +20,16 @@ export interface StringTable {
   ariaRunning: string;
   ariaFinished: string;
   ariaUnavailable: string;
+  ariaStarting: (durationLabel: string) => string;
+  ariaRestarting: (durationLabel: string) => string;
+  pendingStartLabel: string;
+  pendingRestartLabel: string;
+  toastStartFailed: string;
+  toastRestartFailed: string;
+  toastEntityUnavailable: (entityId: string) => string;
+  restartConfirmMessage: (durationLabel: string) => string;
+  restartConfirmConfirm: string;
+  restartConfirmCancel: string;
   entityUnavailableWithId: (entityId: string) => string;
   validation: {
     notAnObject: string;
@@ -58,6 +68,16 @@ export const STRINGS: StringTable = {
   ariaRunning: "Timer running.",
   ariaFinished: "Timer finished.",
   ariaUnavailable: "Timer unavailable.",
+  ariaStarting: (durationLabel: string) => "Starting timer for " + durationLabel + ".",
+  ariaRestarting: (durationLabel: string) => "Restarting timer for " + durationLabel + ".",
+  pendingStartLabel: "Starting…",
+  pendingRestartLabel: "Restarting…",
+  toastStartFailed: "Couldn't start the timer. Please try again.",
+  toastRestartFailed: "Couldn't restart the timer. Please try again.",
+  toastEntityUnavailable: (entityId: string) => "Timer entity " + entityId + " is unavailable.",
+  restartConfirmMessage: (durationLabel: string) => "Restart the timer for " + durationLabel + "?",
+  restartConfirmConfirm: "Restart",
+  restartConfirmCancel: "Cancel",
   entityUnavailableWithId: (entityId: string) => `Entity unavailable (${entityId}).`,
   validation: {
     notAnObject: "Card configuration must be an object.",

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -9,6 +9,7 @@ export const cardStyles = css`
     display: flex;
     flex-direction: column;
     gap: 16px;
+    position: relative;
   }
 
   .header {
@@ -130,5 +131,109 @@ export const cardStyles = css`
 
   .errors li + li {
     margin-top: 4px;
+  }
+
+  .action-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    background: rgba(255, 255, 255, 0.78);
+    backdrop-filter: blur(2px);
+    font-weight: 600;
+    color: var(--primary-text-color, #1f2933);
+    pointer-events: none;
+    text-align: center;
+  }
+
+  .spinner {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 3px solid rgba(0, 0, 0, 0.12);
+    border-top-color: var(--info-color, rgba(0, 122, 255, 0.6));
+    animation: tea-timer-spin 900ms linear infinite;
+  }
+
+  @keyframes tea-timer-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .confirm-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.45);
+    padding: 16px;
+    z-index: 2;
+  }
+
+  .confirm-surface {
+    background: var(--ha-card-background, #fff);
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 260px;
+    width: 100%;
+  }
+
+  .confirm-message {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--primary-text-color, #1f2933);
+  }
+
+  .confirm-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  .confirm-actions button {
+    border: none;
+    border-radius: 8px;
+    padding: 6px 12px;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+
+  .confirm-primary {
+    background: var(--primary-color, #1f2933);
+    color: #fff;
+  }
+
+  .confirm-secondary {
+    background: rgba(0, 0, 0, 0.08);
+    color: var(--primary-text-color, #1f2933);
+  }
+
+  .toast {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 16px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #fff;
+    z-index: 3;
+  }
+
+  .toast-error {
+    background: rgba(191, 26, 47, 0.9);
+  }
+
+  .toast-info {
+    background: rgba(0, 0, 0, 0.75);
   }
 `;

--- a/src/types/home-assistant.ts
+++ b/src/types/home-assistant.ts
@@ -52,6 +52,7 @@ export interface HomeAssistant {
   };
   states: Record<string, HassEntity | undefined>;
   connection?: HassConnection;
+  callService(domain: string, service: string, data?: Record<string, unknown>): Promise<unknown>;
 }
 
 export type LovelaceCardConstructor = new () => LovelaceCard & HTMLElement;

--- a/src/view/TeaTimerViewModel.test.ts
+++ b/src/view/TeaTimerViewModel.test.ts
@@ -13,6 +13,7 @@ const config: TeaTimerConfig = {
   ],
   cardInstanceId: "test",
   dialBounds: { min: 15, max: 1200, step: 5 },
+  confirmRestart: false,
 };
 
 describe("createTeaTimerViewModel", () => {
@@ -31,6 +32,9 @@ describe("createTeaTimerViewModel", () => {
     expect(viewModel.ui.presets[0].durationLabel).toBe("2:00");
     expect(viewModel.dial.selectedDurationSeconds).toBe(180);
     expect(viewModel.dial.bounds).toEqual(config.dialBounds);
+    expect(viewModel.selectedDurationSeconds).toBe(180);
+    expect(viewModel.ui.confirmRestart).toBe(false);
+    expect(viewModel.ui.pendingAction).toBe("none");
   });
 
   it("falls back to defaults when title missing", () => {
@@ -44,6 +48,7 @@ describe("createTeaTimerViewModel", () => {
     expect(viewModel.ui.entityLabel).toBe("Timer entity not configured.");
     expect(viewModel.ui.hasPresets).toBe(false);
     expect(viewModel.dial.selectedDurationSeconds).toBe(config.dialBounds.min);
+    expect(viewModel.selectedDurationSeconds).toBe(config.dialBounds.min);
   });
 
   it("retains user-selected duration while idle when state unchanged", () => {
@@ -62,6 +67,7 @@ describe("createTeaTimerViewModel", () => {
     });
 
     expect(nextViewModel.dial.selectedDurationSeconds).toBe(305);
+    expect(nextViewModel.selectedDurationSeconds).toBe(305);
   });
 
   it("syncs to Home Assistant updates when idle duration changes", () => {
@@ -85,5 +91,6 @@ describe("createTeaTimerViewModel", () => {
     });
 
     expect(viewModel.dial.selectedDurationSeconds).toBe(260);
+    expect(viewModel.selectedDurationSeconds).toBe(260);
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom/vitest";
+
+(globalThis as { litDisableWarning?: Record<string, boolean> }).litDisableWarning = {
+  ...(globalThis as { litDisableWarning?: Record<string, boolean> }).litDisableWarning,
+  "class-field-shadowing": true,
+};


### PR DESCRIPTION
## Summary
- add a dedicated HA timer service wrapper that issues `timer.start` and the prescribed `timer.cancel`+`timer.start` restart chain using normalized seconds
- extend the card/view-model to track pending actions, confirmation prompts, ARIA announcements, and transient toasts while preserving HA as the source of truth for state clearing
- document the new `confirmRestart` option and start/restart flow plus guard user interactions behind the pending overlay for predictable UX

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Acceptance Criteria
- [x] Idle tap starts the timer with pending overlay — covered by `TeaTimerCard` "starts the timer when tapping the card from idle"
- [x] Running tap restarts via cancel+start with overlay — covered by `TeaTimerCard` "restarts the timer when tapping while running"
- [x] Confirm restart gate when `confirmRestart=true` — covered by `TeaTimerCard` "requires confirmation before restarting when confirmRestart is true"
- [x] Ignore taps while pending — covered by `TeaTimerCard` "ignores repeated taps while an action is pending"
- [x] Surface toast on service failure — covered by `TeaTimerCard` "shows an error toast when the service call fails"
- [x] Block actions when entity unavailable — covered by `TeaTimerCard` "announces entity unavailable when tapped"
- [x] Clamp duration per dial bounds — covered by `TeaTimerCard` "clamps the duration before calling Home Assistant"
- [x] Clear pending on HA sync (multi browser) — covered by `TeaTimerCard` "clears the pending action when Home Assistant reports running"

## Follow-ups / Open questions
- consider deferring to HA's implicit restart semantics instead of cancel+start if event ordering proves sufficient
- refine toast copy/timing once real HA error surfaces are observed
- evaluate whether to send duration as formatted strings for locales that expect `HH:MM:SS` inputs

------
https://chatgpt.com/codex/tasks/task_e_68d80f22bc0883338817a672c05310aa