### PR TITLE
[card] Add beverage preset chips (static)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To experiment locally, run `npm run dev` and open the playground at http://local
    type: custom:tea-timer-card
    title: Kitchen Tea Timer
    entity: timer.kitchen_tea
+   defaultPreset: Black Tea
    presets:
      - label: Green Tea
        durationSeconds: 120
@@ -94,6 +95,8 @@ To experiment locally, run `npm run dev` and open the playground at http://local
    stepSeconds: 10
    confirmRestart: true # optional—require confirmation before restarting a running timer
    ```
+
+   Preset chips render in the order provided. Set `defaultPreset` to the label or zero-based index of the preset you want selected when the card loads; if omitted, the first preset is used. Selecting a preset while the timer is idle updates the dial immediately, while taps during a brew queue the new selection for the next restart and surface a “Next: …” subtitle.
 
 ### Documentation
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -172,6 +172,7 @@
         {
           title: "Kitchen Tea Timer",
           entity: "timer.kitchen_tea",
+          defaultPreset: "Black",
           presets: [
             { label: "Green", durationSeconds: 120 },
             { label: "Black", durationSeconds: 240 },

--- a/src/model/config.test.ts
+++ b/src/model/config.test.ts
@@ -41,15 +41,6 @@ describe("parseTeaTimerConfig", () => {
     expect(result.config?.presets).toHaveLength(8);
   });
 
-  it("flags reserved options", () => {
-    const result = parseTeaTimerConfig({
-      presets: [],
-      defaultPreset: 1,
-    });
-
-    expect(result.errors).toContain('The "defaultPreset" option is reserved for a future release.');
-  });
-
   it("parses confirmRestart flag", () => {
     const result = parseTeaTimerConfig({
       entity: "timer.test",
@@ -104,5 +95,33 @@ describe("parseTeaTimerConfig", () => {
     });
 
     expect(result.errors).toContain('The "entity" option is required.');
+  });
+
+  it("selects default preset by index", () => {
+    const result = parseTeaTimerConfig({
+      entity: "timer.test",
+      presets: [
+        { label: "Green", durationSeconds: 120 },
+        { label: "Black", durationSeconds: 240 },
+      ],
+      defaultPreset: 1,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.config?.defaultPresetId).toBe(1);
+  });
+
+  it("selects default preset by label", () => {
+    const result = parseTeaTimerConfig({
+      entity: "timer.test",
+      presets: [
+        { label: "Green", durationSeconds: 120 },
+        { label: "Black", durationSeconds: 240 },
+      ],
+      defaultPreset: "Black",
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.config?.defaultPresetId).toBe(1);
   });
 });

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -28,6 +28,7 @@ export interface TeaTimerConfig {
   cardInstanceId: string;
   dialBounds: DurationBounds;
   confirmRestart: boolean;
+  defaultPresetId?: number;
 }
 
 export interface ParsedTeaTimerConfig {
@@ -35,7 +36,7 @@ export interface ParsedTeaTimerConfig {
   errors: string[];
 }
 
-const RESERVED_OPTIONS = new Set(["defaultPreset", "finishedAutoIdleMs"]);
+const RESERVED_OPTIONS = new Set(["finishedAutoIdleMs"]);
 
 const DEFAULT_MIN_DURATION_SECONDS = 15;
 const DEFAULT_MAX_DURATION_SECONDS = 1200;
@@ -150,6 +151,22 @@ export function parseTeaTimerConfig(input: unknown): ParsedTeaTimerConfig {
     }
   }
 
+  let defaultPresetId: number | undefined;
+  if (Array.isArray(presets) && presets.length) {
+    const defaultPreset = raw.defaultPreset;
+    if (typeof defaultPreset === "number" && Number.isFinite(defaultPreset)) {
+      const index = Math.floor(defaultPreset);
+      if (index >= 0 && index < presets.length) {
+        defaultPresetId = index;
+      }
+    } else if (typeof defaultPreset === "string") {
+      const index = presets.findIndex((preset) => preset.label === defaultPreset);
+      if (index >= 0) {
+        defaultPresetId = index;
+      }
+    }
+  }
+
   const dialBounds: DurationBounds = {
     min: Math.min(minDurationSeconds, maxDurationSeconds),
     max: Math.max(minDurationSeconds, maxDurationSeconds),
@@ -166,6 +183,7 @@ export function parseTeaTimerConfig(input: unknown): ParsedTeaTimerConfig {
     cardInstanceId: createCardInstanceId(),
     dialBounds,
     confirmRestart,
+    defaultPresetId,
   };
 
   return { config, errors };

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -6,6 +6,9 @@ export interface StringTable {
   gettingStartedLabel: string;
   gettingStartedUrl: string;
   presetsGroupLabel: string;
+  presetsMissing: string;
+  presetsCustomLabel: string;
+  presetsQueuedLabel: (label: string, durationLabel: string) => string;
   statusIdle: string;
   statusRunning: string;
   statusFinished: string;
@@ -54,6 +57,10 @@ export const STRINGS: StringTable = {
   gettingStartedLabel: "Getting Started",
   gettingStartedUrl: "https://github.com/sharwell/ha-tea-timer/blob/main/docs/getting-started.md",
   presetsGroupLabel: "Presets",
+  presetsMissing: "Add at least one preset to start brewing.",
+  presetsCustomLabel: "Custom duration",
+  presetsQueuedLabel: (label: string, durationLabel: string) =>
+    `Next: ${label} ${durationLabel}`,
   statusIdle: "Idle",
   statusRunning: "Running",
   statusFinished: "Finished",

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -30,6 +30,12 @@ export const cardStyles = css`
     word-break: break-word;
   }
 
+  .subtitle {
+    font-size: 0.85rem;
+    color: var(--secondary-text-color, #52606d);
+    margin: -8px 0 0;
+  }
+
   .dial-wrapper {
     display: flex;
     flex-direction: column;
@@ -89,7 +95,7 @@ export const cardStyles = css`
   }
 
   .preset-chip {
-    border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+    border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.2));
     border-radius: 16px;
     padding: 6px 12px;
     background: var(--chip-background-color, rgba(0, 0, 0, 0.04));
@@ -98,11 +104,38 @@ export const cardStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    cursor: not-allowed;
+    cursor: pointer;
+    transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
   }
 
-  .preset-chip[disabled] {
-    opacity: 0.6;
+  .preset-chip:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.4);
+  }
+
+  .preset-chip.preset-selected {
+    background: rgba(0, 122, 255, 0.12);
+    border-color: rgba(0, 122, 255, 0.3);
+    color: var(--primary-text-color, #1f2933);
+  }
+
+  .preset-chip.preset-queued {
+    border-style: dashed;
+  }
+
+  .preset-label {
+    font-weight: 600;
+  }
+
+  .preset-duration {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .preset-custom {
+    display: inline-block;
+    margin-top: 4px;
+    font-size: 0.8rem;
+    color: var(--secondary-text-color, #52606d);
   }
 
   .empty-state {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,3 +4,5 @@ import "@testing-library/jest-dom/vitest";
   ...(globalThis as { litDisableWarning?: Record<string, boolean> }).litDisableWarning,
   "class-field-shadowing": true,
 };
+
+(globalThis as { litDisableNativeSupportWarnings?: boolean }).litDisableNativeSupportWarnings = true;


### PR DESCRIPTION
## Summary
- add interactive preset chips with default selection, custom indicators, and queued restart messaging in `TeaTimerCard`
- extend the view model to normalize preset durations, track selected/queued preset IDs, and expose pending duration state
- refresh documentation, demo configuration, styles, and tests to cover preset behaviors and friendly errors when presets are missing

## Testing
- npm test
- npm run lint
- npm run typecheck
- npm run build

## Acceptance Criteria
- [x] Chips render in order with default preset selection (`TeaTimerCard.test.ts` "selects the configured default preset on load")
- [x] Idle preset selection updates pending duration and dial (`TeaTimerCard.test.ts` "queues presets while running and surfaces next message" covers pending state updates and queued messaging)
- [x] Running preset selection queues next duration and surfaces subtitle (`TeaTimerCard.test.ts` "queues presets while running and surfaces next message")
- [x] Restart applies queued preset and clears queue (`TeaTimerCard.test.ts` "restarts with queued preset and clears the queue")
- [x] Queued preset applied on restart/idle transition (`TeaTimerCard.test.ts` "applies queued presets when the timer returns to idle")
- [x] Missing presets show friendly error (`TeaTimerCard.test.ts` "renders a helpful message when presets are missing")
- [x] Dial custom value removes preset highlight (`TeaTimerCard.test.ts` "shows custom preset indicator after dial adjustment")
- [x] Preset durations respect dial bounds (`TeaTimerViewModel.test.ts` and `TeaTimerCard.test.ts` coverage for normalization/clamping)

## Follow-ups / Open Questions
- Further accessibility tweaks and theming polish for preset chips could be explored in a later milestone.

------
https://chatgpt.com/codex/tasks/task_e_68d83f3f855c8333a42a1ff0200cbebf