### PR TITLE
[docs] Milestone 12 — User & Developer Guides + Example Configs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'examples/**'
+      - '.github/workflows/docs.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run documentation checks
+        run: npm run docs:check

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD004": false,
+  "MD029": false,
+  "MD036": false,
+  "MD033": false
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Tea Timer is a custom Lovelace card for Home Assistant that helps you brew the p
 - Node.js 18+
 - npm 9+
 
+> **New to Home Assistant?** Follow the [Quick Start guide](docs/quick-start.md) for an end-to-end
+> walkthrough that covers helpers, installation, and first-run validation.
+
 ### Installation
 
 #### Via HACS (recommended)
@@ -70,7 +73,7 @@ npm ci
 - **No live updates**: Ensure the Home Assistant WebSocket connection is available. The card falls back to the latest `hass` object update but real-time updates rely on the connection being online.
 - **Estimated remaining time**: If Home Assistant does not provide `remaining`, the card estimates the value. When the estimate drifts more than ~2 seconds, a note appears until Home Assistant reports an authoritative value.
 
-To experiment locally, run `npm run dev` and open the playground at http://localhost:5173/. The demo page includes controls to simulate timer runs, finished events, and unavailable states.
+To experiment locally, run `npm run dev` and open the playground at <http://localhost:5173/>. The demo page includes controls to simulate timer runs, finished events, and unavailable states.
 
 ### Using the Card in Home Assistant
 
@@ -85,28 +88,28 @@ To experiment locally, run `npm run dev` and open the playground at http://local
 
 4. Configure the card in Lovelace:
 
-   ```yaml
-   type: custom:tea-timer-card
-   title: Kitchen Tea Timer
-   entity: timer.kitchen_tea
-   defaultPreset: Black Tea
-   presets:
-     - label: Green Tea
-       durationSeconds: 120
-     - label: Black Tea
-       durationSeconds: 240
-  ```
+    ```yaml
+    type: custom:tea-timer-card
+    title: Kitchen Tea Timer
+    entity: timer.kitchen_tea
+    defaultPreset: Black Tea
+    presets:
+      - label: Green Tea
+        durationSeconds: 120
+      - label: Black Tea
+        durationSeconds: 240
+    ```
 
    Optional dial bounds (add alongside the other card options):
 
-   ```yaml
-   minDurationSeconds: 30
-   maxDurationSeconds: 900
-   stepSeconds: 10
-   confirmRestart: true # optional—require confirmation before restarting a running timer
-   finishedAutoIdleMs: 7000 # optional—show the Done overlay before returning to Idle
-   disableClockSkewEstimator: true # optional—seed countdowns from the local clock instead of HA timestamps
-  ```
+    ```yaml
+    minDurationSeconds: 30
+    maxDurationSeconds: 900
+    stepSeconds: 10
+    confirmRestart: true # optional—require confirmation before restarting a running timer
+    finishedAutoIdleMs: 7000 # optional—show the Done overlay before returning to Idle
+    disableClockSkewEstimator: true # optional—seed countdowns from the local clock instead of HA timestamps
+    ```
 
    Preset chips render in the order provided. Set `defaultPreset` to the label or zero-based index of the preset you want selected when the card loads; if omitted, the first preset is used. Selecting a preset while the timer is idle updates the dial immediately, while taps during a brew queue the new selection for the next restart and surface a “Next: …” subtitle.
 
@@ -118,8 +121,17 @@ To experiment locally, run `npm run dev` and open the playground at http://local
 
 ### Documentation
 
-- [Getting Started Guide](docs/getting-started.md)
+- [Quick Start](docs/quick-start.md)
+- [Configuration reference](docs/configuration-reference.md)
+- [Presets and durations](docs/presets-and-durations.md)
+- [State & actions](docs/state-and-actions.md)
 - [Automate on `timer.finished`](docs/automations/finished.md)
+- [Multi-instance & sync](docs/multi-instance-and-sync.md)
+- [Accessibility & reduced motion](docs/accessibility-and-reduced-motion.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Frequently asked questions](docs/faq.md)
+- [Contributing & support](docs/contributing-and-support.md)
+- [Changelog & versioning](docs/changelog-and-versioning.md)
 
 Below is a crisp, implementation‑ready specification for a **Tea Timer Card** as an independent Home Assistant extension (custom Lovelace card + optional helper). It’s organized into **MVD** (minimum viable deliverable) and **Post‑MVD**. Every item is numbered for easy re‑ordering. After the spec, you’ll find a set of **concrete unit milestones**.
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "ignorePaths": [
+    "node_modules",
+    "dist",
+    "package-lock.json"
+  ],
+  "words": [
+    "Lovelace",
+    "WebSocket",
+    "Oolong",
+    "Ristretto",
+    "Lungo",
+    "Assam",
+    "Sencha",
+    "HomeAssistant",
+    "automations",
+    "Automations",
+    "HACS",
+    "hass",
+    "Toggleable",
+    "autoplay",
+    "multi",
+    "prefers",
+    "websockets"
+  ]
+}

--- a/docs/accessibility-and-reduced-motion.md
+++ b/docs/accessibility-and-reduced-motion.md
@@ -1,0 +1,57 @@
+# Accessibility & reduced motion
+
+Tea Timer Card is designed to work with screen readers, keyboards, and reduced-motion preferences.
+Use these notes to verify behavior during accessibility reviews.
+
+## Focus order
+
+1. Title (if present) is skipped to keep focus on interactive elements.
+2. Preset chips appear left-to-right.
+3. The card body (start/restart surface) is last.
+
+Keyboard users can cycle through presets with **Tab**/**Shift+Tab** and activate the focused control
+with **Space** or **Enter**. The card exposes ARIA labels that include the preset name and formatted
+duration (for example, “Preset Green Tea – 2 minutes”).
+
+## Slider semantics
+
+- The dial uses `role="slider"` while idle and publishes `aria-valuemin`, `aria-valuemax`, and
+  `aria-valuenow` reflecting the configured bounds and duration.
+- Arrow keys adjust the value by `stepSeconds`; **PageUp/PageDown** add or subtract 30 seconds; the
+  **Home** and **End** keys jump to the minimum and maximum bounds.
+- While the timer runs the dial switches to a progress indicator with `aria-busy="true"` so screen
+  readers understand that it is not editable.
+
+## Live regions
+
+- Remaining time announcements are throttled to avoid overwhelming assistive technology
+  (30 s ≥ 2:00, 10 s ≥ 1:00, 5 s ≥ 0:20, 1 s < 0:10).
+- Start, restart, finish, and queued preset messages use a polite live region so they do not interrupt
+  ongoing announcements.
+- Error banners use `role="alert"` to ensure critical issues (such as missing entities) are announced
+  immediately.
+
+## Reduced motion & high contrast
+
+- When the operating system reports `prefers-reduced-motion: reduce`, the card disables dial sweep
+  animations and replaces spinners with static indicators.
+- High-contrast and forced-colors modes rely on system colors for primary buttons and text to maintain
+  readability.
+- The finished overlay fades in/out without blur effects so it remains legible with contrast themes.
+
+## Screen reader testing checklist
+
+1. Navigate through presets and the card body using only the keyboard.
+2. Start a brew and confirm you hear a single announcement for the selected preset and duration.
+3. Queue a different preset mid-brew and verify the “Next preset” announcement.
+4. Wait for the brew to finish; listen for the completion message.
+5. Simulate an unavailable entity (disable the timer helper) and confirm the alert is announced.
+
+## Troubleshooting accessibility issues
+
+- **No announcements:** Check your screen reader verbosity and ensure the browser allows live region
+  updates. The card avoids aria-live="assertive" to reduce interruption.
+- **Focus trapped:** Confirm custom dashboards do not wrap the card in containers that alter focus
+  order (such as negative `tabindex`).
+- **Animations still playing:** Some browsers cache motion preferences. Reload the page or toggle the
+  OS setting to refresh the media query.

--- a/docs/automations/finished.md
+++ b/docs/automations/finished.md
@@ -1,69 +1,102 @@
 # Automate on `timer.finished`
 
-The Tea Timer Card relies on Home Assistant’s native [`timer` integration](https://www.home-assistant.io/integrations/timer/).
-When a timer completes, Home Assistant emits a `timer.finished` event that includes the
-`entity_id` and `finished_at` timestamp. You can hook your own automations into this event to play
-sounds, flash lights, or send notifications.
+Tea Timer Card shows a **Done** overlay when Home Assistant emits `timer.finished`. Attach your own
+automations to play a chime, flash lights, or send notifications.
 
-This guide walks through a lightweight QA automation you can enable while evaluating the card. It
-also calls out the edge cases that the card purposely leaves to Home Assistant.
+## Prerequisites
 
-## Demo QA automation
+- A timer helper entity (for example `timer.kitchen_tea`).
+- Tea Timer Card installed and bound to that entity.
+- Home Assistant automation editor access (UI or YAML).
 
-The card’s playground (`npm run dev`) now includes a demo automation logger. Click **Emit finished
-event** to fire `timer.finished`; the logger records the event and the time it took for each card on
-the page to show the "Done" overlay. The delay stays under 500 ms so you can validate that the UI
-and automation fire in lock-step.
+## Step-by-step: notification automation
 
-The same pattern works in Home Assistant. The YAML below creates a persistent notification any time
-`timer.kitchen_tea` finishes:
+1. Open **Settings → Automations & Scenes**.
+2. Click **Create automation → From scratch**.
+3. Set a name such as **Tea timer finished – notify**.
+4. Add a trigger with **Event** type, event type `timer.finished`, and set the event data to the YAML
+   snippet below.
 
 ```yaml
-alias: QA – Tea timer finished
+entity_id: timer.kitchen_tea
+```
+
+5. Add an action. The example below sends a persistent notification:
+
+```yaml
+service: persistent_notification.create
+data:
+  title: Tea timer finished
+  message: |
+    Timer finished at {{ trigger.event.data.finished_at }}.
+    Remaining: {{ state_attr('timer.kitchen_tea', 'remaining') | default('unknown') }}
+```
+
+6. Save the automation.
+
+Start a brew from the Tea Timer Card and let it finish. You should receive the notification at the
+same moment the card displays **Done**.
+
+## Example: shared automation for two timers
+
+Use a condition to branch based on the entity that triggered the finish:
+
+```yaml
+alias: Tea timers – finish handler
 triggers:
   - platform: event
     event_type: timer.finished
     event_data:
-      entity_id: timer.kitchen_tea
+      entity_id:
+        - timer.kitchen_tea
+        - timer.living_room_tea
 actions:
-  - service: persistent_notification.create
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.entity_id == 'timer.kitchen_tea' }}"
+        sequence:
+          - service: notify.family
+            data:
+              message: Kitchen tea is ready!
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.entity_id == 'timer.living_room_tea' }}"
+        sequence:
+          - service: light.turn_on
+            target:
+              entity_id: light.living_room_lamp
+            data:
+              flash: long
+  - service: logbook.log
     data:
-      title: Tea timer finished
-      message: |
-        Timer finished at {{ trigger.event.data.finished_at }}.
-        Remaining: {{ state_attr('timer.kitchen_tea', 'remaining') | default('unknown') }}
-mode: single
+      name: Tea Timer Card
+      message: "{{ trigger.event.data.entity_id }} finished at {{ trigger.event.data.finished_at }}"
+mode: parallel
 ```
 
-### What to expect
+## Manual testing checklist
 
-Run through the following scenarios to confirm the integration behaves as expected:
+1. **Normal finish:** Start a 10 s brew and wait. Verify the automation fires once.
+2. **Restart mid-run:** Restart a running timer. Only the completion after the restart should fire.
+3. **Cancel:** Call `timer.cancel`; no automation should run.
+4. **Multi-device:** Start the timer from a second device. Automation still fires once.
+5. **Home Assistant restart:** Start a brew, restart Home Assistant before it finishes, and note that
+   no `timer.finished` event is replayed. Consider a startup automation if you need catch-up logic.
 
-1. **Legitimate finish** – start a 5 s timer. When it completes you should see one notification and
-   the card will display "Done" for five seconds.
-2. **Restart mid-run** – start a 10 s timer and restart it around the 6 s mark. Only the final
-   completion triggers the automation.
-3. **Cancel** – start a timer and cancel it. The automation does not run.
-4. **Multi-view sync** – open the dashboard on two devices. Start and finish a timer from either
-   device; both sessions show the "Done" overlay together and the automation fires once.
-5. **Unavailable entity** – set the timer entity to unavailable (e.g., remove it or disable the
-   integration). The card surfaces the error and the automation does not run.
-6. **Ultra-short runs** – run a one-second timer. The automation fires once without overlay flicker.
+## Edge cases & guidance
 
-The demo logger in `npm run dev` mirrors these scenarios so you can rehearse locally before testing
-inside Home Assistant.
+- Home Assistant does **not replay** missed `timer.finished` events after restarts. If this matters,
+  add an automation on `homeassistant.start` to inspect timers with `remaining` less than or equal to
+  zero.
+- Restarting the timer via the card issues `timer.cancel` followed by `timer.start`. Only the final
+  finish fires the event, so your automation will not run twice.
+- Always filter on `event_data.entity_id` to avoid triggering from unrelated timers.
+- Ultra-short runs (≤1 s) still emit `timer.finished`; consider debouncing if you chain multiple
+  actions.
 
-## Limitations and guidance
+## Troubleshooting
 
-- Home Assistant does **not replay** missed finishes after a restart. If a timer would have expired
-  while Home Assistant was offline, `timer.finished` is not fired on startup. Consider adding a
-  startup automation that inspects `states.timer` to detect expired timers if you need to handle
-  that case.
-- The card restarts a running timer by calling `timer.cancel` followed by `timer.start` so you always
-  get the `timer.finished` event only for the latest brew.
-- When a timer is cancelled or restarted before finishing, Home Assistant **does not** emit
-  `timer.finished`. Any automation driven by that event will also skip those runs.
-- Automations should always filter on `event_data.entity_id` to avoid triggering from unrelated
-  timers. The `finished_at` stamp is helpful for logging or calculating drift.
-- The card delegates all actions (chimes, lights, etc.) to Home Assistant automations. It does not
-  play sounds, vibrate, or retry missed finishes on the client.
+- Use **Developer Tools → Events** to listen for `timer.finished` while testing.
+- Check the automation trace if an action does not execute.
+- Review [Troubleshooting](../troubleshooting.md#automations-not-firing) for additional guidance.

--- a/docs/changelog-and-versioning.md
+++ b/docs/changelog-and-versioning.md
@@ -1,0 +1,37 @@
+# Changelog & versioning
+
+Tea Timer Card follows semantic versioning. Use this page to find release notes and understand what
+changes to expect when updating.
+
+## Version numbers
+
+- **Major (`X.0.0`):** Reserved for breaking changes. The card is still in preview, so expect 0.x
+  releases until the API stabilizes.
+- **Minor (`0.Y.0`):** New features, presets, or configuration options that remain backward
+  compatible.
+- **Patch (`0.1.Z`):** Bug fixes and documentation updates with no new configuration surface.
+
+## Release notes
+
+All releases are documented in [`CHANGELOG.md`](../CHANGELOG.md). Each entry lists notable features,
+bug fixes, and documentation updates.
+
+## Preview builds
+
+During active development, preview builds may be published to gather feedback. These builds keep the
+same configuration surface as the upcoming release. Expect rapid iteration and report issues quickly
+so they can be addressed before the final release.
+
+## Staying up to date
+
+- Subscribe to repository notifications or watch releases on GitHub.
+- When updating through HACS, review the changelog entry before installing.
+- Re-run `npm run build` after pulling new commits if you self-host the bundle.
+
+## Rollback plan
+
+If you encounter issues after updating:
+
+1. Revert to the previous tag or commit in your deployment.
+2. Restore the matching documentation version from your backup or the repository history.
+3. Open an issue describing the regression so maintainers can address it in the next patch release.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1,0 +1,132 @@
+# Configuration reference
+
+Every Tea Timer Card instance is defined with YAML (in Lovelace or the UI editor). This reference
+covers each supported option, its default, and example uses. Options marked **Required** must be
+provided for the card to load.
+
+## Card-level options
+
+### `type` — **Required**
+
+- **Description:** Identifies the custom card. Lovelace sets this automatically when you pick the
+  card from the UI selector.
+- **Default:** `custom:tea-timer-card`
+- **Example:** Always leave the default unless you are debugging multiple card versions locally.
+
+### `entity` — **Required**
+
+- **Description:** Home Assistant `timer` entity the card controls and listens to.
+- **Default:** None. The card shows an error until a valid timer id is supplied.
+- **Example:** `entity: timer.kitchen_tea` links the card to a kitchen timer helper.
+
+### `title`
+
+- **Description:** Text shown at the top of the card.
+- **Default:** No title (the entity id appears in smaller text instead).
+- **Example:** `title: Kitchen Tea Timer` helps differentiate multiple cards on the same view.
+
+### `presets`
+
+- **Description:** List of preset buttons a user can select. Each preset needs a `label` and a
+  `durationSeconds` value greater than zero.
+- **Default:** No presets. The dial still works, but users choose durations manually.
+- **Example:**
+
+  ```yaml
+  presets:
+    - label: Green Tea
+      durationSeconds: 120
+    - label: Oolong
+      durationSeconds: 180
+    - label: Herbal
+      durationSeconds: 300
+  ```
+
+  Add up to eight presets to cover your favorite brews.
+
+### `defaultPreset`
+
+- **Description:** Preset that is selected automatically when the card loads.
+- **Default:** The first preset, if any.
+- **Example:** `defaultPreset: Oolong` loads the preset with that label. Alternatively, use
+  `defaultPreset: 2` to select the third preset in the list.
+
+### `minDurationSeconds`
+
+- **Description:** Smallest allowed duration for the dial when the timer is idle.
+- **Default:** `15` seconds.
+- **Example:** `minDurationSeconds: 30` ensures quick taps never start a brew shorter than 30 seconds.
+
+### `maxDurationSeconds`
+
+- **Description:** Largest allowed duration for the dial.
+- **Default:** `1200` seconds (20 minutes).
+- **Example:** `maxDurationSeconds: 900` limits the dial to a 15-minute maximum brew.
+
+### `stepSeconds`
+
+- **Description:** Increment used when dragging the dial or pressing arrow keys.
+- **Default:** `5` seconds.
+- **Example:** `stepSeconds: 10` creates a coarser dial that moves in 10-second increments.
+
+### `confirmRestart`
+
+- **Description:** Adds a confirmation dialog before restarting a running timer. Helps prevent
+  accidental restarts when multiple people use the timer.
+- **Default:** `false` (restarts immediately).
+- **Example:** `confirmRestart: true` forces a confirmation dialog before canceling a brew in
+  progress.
+
+### `finishedAutoIdleMs`
+
+- **Description:** Duration that the **Done** overlay remains before the card returns to Idle.
+- **Default:** `5000` milliseconds (5 seconds).
+- **Example:** `finishedAutoIdleMs: 7000` keeps the completion overlay visible for seven seconds so
+  everyone can see it.
+
+### `disableClockSkewEstimator`
+
+- **Description:** When `false` (default) the card smooths remaining-time estimates between Home
+  Assistant updates. Set to `true` to disable the estimator and rely solely on the browser clock.
+- **Default:** `false` (estimator enabled).
+- **Example:** `disableClockSkewEstimator: true` is useful if you run a kiosk that routinely loses
+  WebSocket updates and you prefer the timer to pause instead of estimating.
+
+## Preset object options
+
+Each entry inside `presets` uses the following keys:
+
+### `label` — **Required**
+
+- **Description:** Text shown on the preset chip and in announcements.
+- **Example:** `label: White Tea`
+
+### `durationSeconds` — **Required**
+
+- **Description:** Length of the brew in seconds. Must be a positive number.
+- **Example:** `durationSeconds: 180` creates a three-minute preset.
+
+## Complete example
+
+```yaml
+type: custom:tea-timer-card
+title: Office Tea Timer
+entity: timer.office_tea
+presets:
+  - label: Sencha
+    durationSeconds: 90
+  - label: Assam
+    durationSeconds: 180
+  - label: Herbal Blend
+    durationSeconds: 300
+defaultPreset: Assam
+minDurationSeconds: 30
+maxDurationSeconds: 1200
+stepSeconds: 5
+confirmRestart: false
+finishedAutoIdleMs: 5000
+```
+
+> Tip: Need YAML for testing or onboarding? Start with the
+> [`single-timer example`](../examples/lovelace/tea-timer-card-basic.yaml) or the
+> [`two-timer layout`](../examples/lovelace/tea-timer-card-two-timers.yaml).

--- a/docs/contributing-and-support.md
+++ b/docs/contributing-and-support.md
@@ -1,0 +1,56 @@
+# Contributing & support
+
+We welcome bug reports, documentation updates, and ideas to improve Tea Timer Card. Use the
+following channels depending on what you need.
+
+## Ask a question or get help
+
+1. Search existing issues to see if your question has already been answered.
+2. Open a new issue with the **Question** template. Include:
+   - Home Assistant version and installation method.
+   - Browser and device details.
+   - Card configuration snippet (redact personal data).
+   - Steps to reproduce the issue.
+3. For automation-specific questions, include the relevant YAML and logs from **Settings → System →
+   Logs** if available.
+
+## Report a bug
+
+1. Verify the issue still occurs on the latest release (check the
+   [Changelog](changelog-and-versioning.md)).
+2. Gather reproduction steps, screenshots (with alt text if you share them), and browser console
+   errors.
+3. Open an issue labeled **bug** and provide the details above.
+
+## Contribute changes
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies and run the local checks:
+
+   ```bash
+   npm ci
+   npm run lint
+   npm run typecheck
+   npm test
+   npm run docs:check
+   ```
+
+3. Update or add documentation as needed—especially when adding new options or user flows.
+4. Submit a pull request describing your change, tests performed, and any follow-up work.
+
+## Documentation improvements
+
+- Found a typo or missing section? Open an issue or submit a pull request with the fix.
+- When adding screenshots, include concise alt text so the docs remain accessible.
+- If you add new pages under `docs/`, remember to update the README **Documentation** section.
+
+## Release cadence
+
+Releases use semantic versioning (`major.minor.patch`). Preview builds may be published for testing
+before a feature lands in stable. See [Changelog & versioning](changelog-and-versioning.md) for the
+latest release notes.
+
+## Need direct support?
+
+Community support happens publicly through GitHub issues to keep solutions discoverable. Sensitive
+security reports can be sent privately to the maintainer via the email listed in `package.json`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,47 @@
+# Frequently asked questions
+
+## Can I pause a brew instead of restarting?
+
+Not yet. The card intentionally exposes start and restart only to stay aligned with Home Assistant’s
+`timer` helper. Pause/resume support is tracked separately and would require changes to the helper
+itself.
+
+## How do I play a sound when the timer finishes?
+
+Attach an automation to `timer.finished`. The example in
+[`docs/automations/finished.md`](automations/finished.md) shows how to trigger a notification, light,
+or speaker.
+
+## Why does the card show an estimated remaining time banner?
+
+When Home Assistant omits the `remaining` attribute (often during reconnects), the card estimates the
+countdown based on the last known duration. The banner disappears after the next authoritative
+update. If you would rather pause than estimate, set `disableClockSkewEstimator: true`.
+
+## Can I run multiple timers on one dashboard?
+
+Yes. Create separate timer helpers and assign each card a unique `entity` value. The
+[`examples/lovelace/tea-timer-card-two-timers.yaml`](../examples/lovelace/tea-timer-card-two-timers.yaml)
+file demonstrates the pattern.
+
+## Does the card work without presets?
+
+Absolutely. Leave the `presets` array empty to rely on the dial alone. The card still remembers the
+last dialed duration between runs.
+
+## How do I localize preset labels?
+
+Preset labels come directly from your YAML configuration. Provide labels in your preferred language or
+include emoji for quick recognition. Time formatting follows your Home Assistant locale.
+
+## What happens after a Home Assistant restart?
+
+Home Assistant restores the timer state but does not emit `timer.finished` events that were missed
+while it was offline. The card reconnects, fetches the latest state, and continues counting down if
+`remaining` is still positive.
+
+## Where can I report issues or request features?
+
+Open an issue on the project’s GitHub repository. Include your Home Assistant version, browser, card
+configuration, and reproduction steps. For quick tips, check the [Troubleshooting](troubleshooting.md)
+page first.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,11 +1,7 @@
 # Tea Timer Card — Getting Started
 
-This is a placeholder for the Tea Timer Card documentation. Future updates will include installation and configuration guidance.
+Looking for setup instructions? The new [Quick start](quick-start.md) guide walks you from creating a
+Home Assistant timer helper to installing the card, adding presets, and running your first brew.
 
-## Dial duration options
-
-- `minDurationSeconds` (default `15`) sets the minimum selectable brew time.
-- `maxDurationSeconds` (default `1200`) caps the dial at 20 minutes by default.
-- `stepSeconds` (default `5`) controls the rounding increment for pointer and keyboard input.
-- The dial is interactive only while the timer is idle; pressing the arrow keys or PageUp/PageDown nudges the value by the configured steps.
-- While the timer is running, the dial renders a theme-aware progress arc that tracks elapsed brew time and respects reduced-motion preferences.
+If you maintain bookmarks to this page, update them to the quick start for the most current
+instructions.

--- a/docs/multi-instance-and-sync.md
+++ b/docs/multi-instance-and-sync.md
@@ -1,0 +1,66 @@
+# Multi-instance & sync
+
+Tea Timer cards stay synchronized through the Home Assistant timer entity they share. Use these
+patterns to build dashboards with one or many timers while keeping every device in lock-step.
+
+```mermaid
+graph TD
+  A[Tea Timer Card \#1] -->|binds entity| T(timer.kitchen_tea)
+  B[Tea Timer Card \#2] -->|binds entity| T
+  C[Automations] -->|listen for timer.finished| T
+  T -->|state_changed| A
+  T -->|state_changed| B
+```
+
+## Single timer on multiple dashboards
+
+- **Use case:** You want the same timer visible on a wall tablet, phone, and desktop view.
+- **Configuration:** Point each card to the same entity id (for example `timer.kitchen_tea`).
+- **Behavior:** Any device can start/restart the timer; others update within a fraction of a second.
+  The **Done** overlay appears everywhere at the same time because each instance receives the same
+  `timer.finished` event.
+
+## Multiple timers in one view
+
+- **Use case:** Separate timers for tea and coffee or different rooms.
+- **Configuration:** Give each card its own timer helper. The
+  [`examples/lovelace/tea-timer-card-two-timers.yaml`](../examples/lovelace/tea-timer-card-two-timers.yaml)
+  file demonstrates two cards that share preset definitions but target `timer.kitchen_tea` and
+  `timer.living_room_tea` respectively.
+- **Behavior:** Cards operate independently—starting one does not affect the other.
+
+## Shared automations
+
+Automations that trigger on `timer.finished` can include multiple timer entities:
+
+```yaml
+triggers:
+  - platform: event
+    event_type: timer.finished
+    event_data:
+      entity_id:
+        - timer.kitchen_tea
+        - timer.living_room_tea
+```
+
+Use conditions or choose actions based on `trigger.event.data.entity_id` to branch per room. The
+[`examples/automations/timer-finished.yaml`](../examples/automations/timer-finished.yaml) sample
+sends different notifications depending on which timer finishes.
+
+## Handling entity renames
+
+If you rename a timer helper, update every card and automation that references it:
+
+1. Edit each Lovelace card and replace the `entity` value.
+2. Update automations to match the new entity id.
+3. Reload the dashboard or refresh the browser to clear cached configuration.
+
+The card detects missing entities and shows an error banner until the configuration is corrected.
+
+## Sync troubleshooting tips
+
+- **Out-of-sync countdowns:** Ensure all clients have a stable WebSocket connection. The card pauses
+  while disconnected and resyncs once reconnected.
+- **Unexpected restarts:** Check for other automations calling `timer.start` on the same entity.
+- **Drift after reconnect:** See [Troubleshooting](troubleshooting.md#countdown-drift-after-reconnect)
+  for guidance on the clock skew estimator and when to disable it.

--- a/docs/presets-and-durations.md
+++ b/docs/presets-and-durations.md
@@ -1,0 +1,65 @@
+# Presets and durations
+
+Presets keep your favorite brew times one tap away. Use this guide to plan and maintain presets that
+match your household’s routine.
+
+## Designing presets
+
+1. **List your beverages.** Capture the teas, coffees, or recipes you brew regularly.
+2. **Assign target durations.** Convert minutes and seconds into `durationSeconds` values.
+3. **Order by frequency.** Place the most-used presets first so they stay within easy reach.
+4. **Keep labels short.** Aim for one or two words so the preset chip remains readable on phones.
+5. **Limit to eight.** The card enforces an upper bound of eight presets to preserve layout and
+   accessibility.
+
+> Tip: You can always start with three presets and expand later. The dial remains available for
+> ad-hoc brews.
+
+## Mixing presets with dial bounds
+
+Dial bounds (`minDurationSeconds`, `maxDurationSeconds`, `stepSeconds`) shape how freeform brews
+behave alongside presets:
+
+- Set `minDurationSeconds` slightly below your shortest preset to leave room for experimentation.
+- Keep `maxDurationSeconds` at or above your longest preset so queued presets never clamp.
+- Reduce `stepSeconds` to `1` or `2` if you brew espresso or teas that need fine-grained control.
+
+Example configuration with fine control for espresso testing:
+
+```yaml
+minDurationSeconds: 10
+maxDurationSeconds: 300
+stepSeconds: 1
+presets:
+  - label: Ristretto
+    durationSeconds: 30
+  - label: Espresso
+    durationSeconds: 40
+  - label: Lungo
+    durationSeconds: 55
+```
+
+## Queueing presets during a brew
+
+Selecting a preset while the timer runs does not interrupt the current brew. Instead:
+
+1. The card announces the next preset (for example, “Next: Herbal 5:00”).
+2. The queued preset appears in the subtitle to signal the pending change.
+3. When you restart the timer—either manually or when it finishes—the queued preset becomes active.
+
+This behavior keeps the running brew predictable while still letting you line up the next tea.
+
+## Sharing presets across multiple cards
+
+Using the same preset definitions across rooms keeps the experience consistent. Place your preset
+YAML in a [Lovelace dashboard template](https://www.home-assistant.io/lovelace/dashboards-and-views/)
+or copy from [`examples/lovelace/tea-timer-card-two-timers.yaml`](../examples/lovelace/tea-timer-card-two-timers.yaml)
+which shows two cards with shared presets and entity overrides.
+
+## Maintaining presets over time
+
+- **Seasonal updates:** Adjust presets when you rotate blends so the defaults stay relevant.
+- **Community feedback:** Encourage household members to suggest changes—shorter herbal preset,
+  longer cold brew, etc.—and record updates in your version control or automation notes.
+- **Backup:** Store your Lovelace YAML in source control or the Home Assistant configuration backup
+  so the presets survive rebuilds.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,92 @@
+# Quick Start — Tea Timer Card
+
+Get a Tea Timer Card up and running in Home Assistant in under ten minutes. This guide assumes you
+have administrative access to Home Assistant and can install custom Lovelace cards.
+
+## 1. Create a timer helper
+
+1. Open **Settings → Devices & services → Helpers**.
+2. Select **Create helper → Timer**.
+3. Name it something memorable such as **Kitchen Tea Timer**.
+4. Leave the duration empty; the card will set it when you start a brew.
+5. Note the generated entity id (for example `timer.kitchen_tea`).
+
+## 2. Install the Tea Timer Card
+
+### Recommended: HACS
+
+1. Install [HACS](https://hacs.xyz/docs/setup/download/) if you have not already.
+2. In **HACS → Integrations**, open the overflow menu and choose **Custom repositories**.
+3. Add `https://github.com/sharwell/ha-tea-timer` with the **Lovelace** category.
+4. Search for **Tea Timer Card** and click **Download**.
+5. When prompted, reload your browser or clear the Lovelace resources cache.
+
+### Manual build
+
+You can build the card locally if you prefer to review the bundle before installing it.
+
+```bash
+npm ci
+npm run build
+```
+
+Copy `dist/tea-timer-card.js` into your Home Assistant `www` folder and add a Lovelace resource:
+
+```yaml
+url: /local/tea-timer-card.js
+type: module
+```
+
+Reload your browser after updating Lovelace resources.
+
+## 3. Add the card to your dashboard
+
+The Tea Timer Card is configurable from the Lovelace UI or YAML editor.
+
+### Lovelace UI editor
+
+1. Open the dashboard where you want the card.
+2. Click **Edit dashboard → Add card → Custom: Tea Timer Card**.
+3. Fill in at least the **Entity** field with your timer helper (`timer.kitchen_tea`).
+4. (Optional) Set a **Title** and add presets under **Presets**.
+5. Save the card.
+
+### YAML example
+
+Paste the following configuration into the YAML editor. Replace the `entity` value with your timer.
+
+```yaml
+type: custom:tea-timer-card
+title: Kitchen Tea Timer
+entity: timer.kitchen_tea
+defaultPreset: Black Tea
+presets:
+  - label: Green Tea
+    durationSeconds: 120
+  - label: Oolong Tea
+    durationSeconds: 180
+  - label: Black Tea
+    durationSeconds: 240
+```
+
+## 4. Start your first brew
+
+1. Tap a preset to select its duration, or turn the dial to a custom time.
+2. Activate the card (tap/click/press **Space** or **Enter**) to start the timer.
+3. Watch the countdown; the dial locks while the timer runs so you cannot change it accidentally.
+4. When the timer finishes, the card displays a five-second **Done** overlay.
+5. Tap the card again to restart with the same duration, or pick a different preset.
+
+## 5. Verify the finished event (optional)
+
+Open **Developer Tools → Events** and listen for `timer.finished`. When the timer completes you will
+see an event for your entity. Use this as a hook for automations—see
+[Automate on `timer.finished`](automations/finished.md) for an end-to-end example.
+
+## Next steps
+
+- Review the [Configuration reference](configuration-reference.md) for every available option.
+- Explore [Presets and durations](presets-and-durations.md) to design presets for your favorite
+  brews.
+- Learn how the card behaves across states in [State & actions](state-and-actions.md).
+- Configure notifications or lights in [Automate on `timer.finished`](automations/finished.md).

--- a/docs/state-and-actions.md
+++ b/docs/state-and-actions.md
@@ -1,0 +1,84 @@
+# State & actions
+
+The Tea Timer Card mirrors the lifecycle of a Home Assistant `timer` entity. Understanding each
+state helps you predict how the card reacts to taps, keyboard input, and automations.
+
+```mermaid
+stateDiagram-v2
+    state Idle {
+        [*] --> IdleReady
+    }
+    Idle --> Running: Start timer
+    Running --> Running: Restart timer
+    Running --> Finished: timer.finished event
+    Finished --> Idle: Auto idle timeout / user restart
+    Idle --> Error: Entity unavailable
+    Error --> Idle: Entity recovers
+```
+
+## Idle
+
+- **What you see:** Dial is interactive, presets respond instantly, subtitle shows the selected
+  preset or custom duration.
+- **Actions available:**
+  - Drag the dial or use arrow keys/PageUp/PageDown to change the duration (rounded to `stepSeconds`).
+  - Tap/click/press **Space** or **Enter** anywhere on the card body to start the timer.
+  - Pick a preset to update the dial.
+- **Announcements:** Screen readers hear the selected preset and duration when it changes.
+
+## Running
+
+- **What you see:** Dial locks, a progress arc fills clockwise, remaining time updates once per
+  second (throttled for screen readers), and queued presets appear as a subtitle.
+- **Actions available:**
+  - Tap/click the card to restart with the queued duration.
+  - Change presets—the card queues the new selection for the next restart without interrupting the
+    current brew.
+  - Cancel or restart the timer from any device; changes propagate immediately.
+- **Announcements:**
+  - Start/restart events use a polite live region (“Brew started for Green Tea – 2 minutes”).
+  - Queued preset announcements (“Next preset selected: Herbal – 5 minutes”).
+
+## Finished (transient)
+
+- **What you see:** The card displays **Done** with an optional preset label. A translucent overlay
+  lasts `finishedAutoIdleMs` milliseconds (default 5000) before returning to Idle.
+- **Actions available:**
+  - Tap/click/press **Space** or **Enter** to restart immediately using the same duration or a queued
+    preset.
+  - Let the overlay expire; the card automatically returns to Idle and restores dial interaction.
+- **Announcements:** “Brew finished – Done” with the preset label when available.
+
+## Error / unavailable
+
+- **What you see:** The card shows an alert banner if the timer entity is missing, unavailable, or
+  mis-typed. The dial and actions are disabled until the entity recovers.
+- **Actions available:** Fix the underlying entity (rename, recreate, or re-enable it). The card
+  resubscribes automatically when the entity becomes available.
+
+## Connection loss
+
+- **What you see:** A “Disconnected” banner and paused countdown while the Home Assistant WebSocket
+  reconnects.
+- **Actions available:** Wait for reconnection or refresh the browser. Once reconnected the card
+  fetches the latest timer state and resumes normal behavior.
+
+## Keyboard & pointer shortcuts
+
+- **Start or restart:** **Space** or **Enter** when the card is focused.
+- **Adjust duration:**
+  - **Arrow keys:** ±`stepSeconds`.
+  - **PageUp/PageDown:** ±30 seconds.
+  - **Home/End:** Jump to min/max bounds.
+- **Confirm restart:** When `confirmRestart` is enabled, the dialog captures focus so keyboard users
+  cannot accidentally dismiss it.
+
+## Service calls
+
+The card never modifies timers locally. Instead it issues Home Assistant service calls:
+
+- `timer.start` with `duration` when starting or restarting.
+- `timer.cancel` immediately followed by `timer.start` when changing durations mid-run.
+
+This approach keeps Home Assistant authoritative for countdowns and ensures events such as
+`timer.finished` fire exactly once per completion.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,76 @@
+# Troubleshooting
+
+Something not working as expected? Use this checklist to diagnose the most common Tea Timer Card
+issues.
+
+## Missing or incorrect entity id
+
+- **Symptom:** Card shows “Entity not found” or displays the wrong timer.
+- **Diagnosis:**
+  1. Open **Settings → Devices & services → Helpers** and confirm the timer helper exists.
+  2. Copy the exact entity id (for example `timer.kitchen_tea`).
+  3. Inspect the Lovelace configuration and verify the `entity` value matches.
+- **Fix:** Update the card configuration and reload the dashboard. The card reconnects automatically
+  when the entity id is corrected.
+
+## WebSocket disconnected
+
+- **Symptom:** Banner reads “Disconnected from Home Assistant,” countdown pauses, and the dial is
+  disabled.
+- **Diagnosis:**
+  1. Check network connectivity between the device and Home Assistant.
+  2. Open the browser developer console; look for WebSocket errors.
+  3. Confirm no reverse proxy or firewall is blocking `/api/websocket`.
+- **Fix:** Restore the network path. The card resumes once the WebSocket reconnects and a fresh state
+  snapshot arrives.
+
+## No live updates (stale countdown)
+
+- **Symptom:** Timer only updates when you refresh the page.
+- **Diagnosis:**
+  1. Verify the Home Assistant WebSocket connection is active (see above).
+  2. Ensure no browser extensions are blocking websockets or JavaScript timers.
+  3. Confirm the Home Assistant instance is not overloaded—check system logs for warnings about event
+     loop delays.
+- **Fix:** Resolve the underlying WebSocket issue or performance bottleneck. The card intentionally
+  relies on server events to stay authoritative.
+
+## Countdown drift after reconnect
+
+- **Symptom:** Remaining time briefly jumps forward/backward when the connection restores.
+- **Diagnosis:**
+  1. Determine whether Home Assistant provided a `remaining` value in the latest update.
+  2. If `remaining` is missing, the card estimates it from `duration` and `last_changed` and flags the
+     drift when it exceeds two seconds.
+- **Fix:** Allow one or two updates after reconnection—the card re-syncs to the server value. If you
+  prefer to pause instead of estimating, set `disableClockSkewEstimator: true` in the card
+  configuration.
+
+## Card unavailable in Lovelace
+
+- **Symptom:** Lovelace shows “Custom element doesn’t exist: tea-timer-card.”
+- **Diagnosis:**
+  1. Confirm the card bundle is installed (via HACS or manually) and appears under **Settings →
+     Dashboards → Resources**.
+  2. Ensure the resource URL matches your deployment (for manual installs it should be
+     `/local/tea-timer-card.js`).
+  3. Clear your browser cache or perform a hard reload to discard stale resources.
+- **Fix:** Add or correct the resource entry, then reload the browser. HACS installations may require a
+  resource refresh after updates.
+
+## Automations not firing
+
+- **Symptom:** `timer.finished` automations never run even though the card shows “Done.”
+- **Diagnosis:**
+  1. Listen for the `timer.finished` event in **Developer Tools → Events** to confirm Home Assistant
+     emits it.
+  2. Check automation trigger filters—ensure `event_data.entity_id` matches your timer id.
+  3. Review Home Assistant logs for automation errors.
+- **Fix:** Update the automation to listen to the correct entity id or adjust conditions. Remember that
+  Home Assistant does not replay finishes missed while it was offline; consider a startup automation
+  if you need catch-up behavior.
+
+## Still stuck?
+
+- Review the [FAQ](faq.md) for quick answers.
+- Ask a question on the project’s issue tracker—include steps to reproduce and any console/log output.

--- a/examples/automations/timer-finished.yaml
+++ b/examples/automations/timer-finished.yaml
@@ -1,0 +1,34 @@
+# Automation: notify when any tea timer finishes.
+# Import into Home Assistant and update entity ids and services to match your setup.
+
+alias: Tea timers – finish handler
+mode: parallel
+triggers:
+  - platform: event
+    event_type: timer.finished
+    event_data:
+      entity_id:
+        - timer.kitchen_tea
+        - timer.living_room_tea
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.entity_id == 'timer.kitchen_tea' }}"
+        sequence:
+          - service: notify.mobile_app_kitchen_tablet
+            data:
+              message: Kitchen tea is ready!
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.entity_id == 'timer.living_room_tea' }}"
+        sequence:
+          - service: light.turn_on
+            target:
+              entity_id: light.living_room_lamp
+            data:
+              flash: long
+  - service: logbook.log
+    data:
+      name: Tea Timer Card
+      message: "{{ trigger.event.data.entity_id }} finished at {{ trigger.event.data.finished_at }}"

--- a/examples/lovelace/tea-timer-card-basic.yaml
+++ b/examples/lovelace/tea-timer-card-basic.yaml
@@ -1,0 +1,18 @@
+# Tea Timer Card — single timer with three presets
+# Replace timer.kitchen_tea with your timer helper entity id.
+
+- type: custom:tea-timer-card
+  title: Kitchen Tea Timer
+  entity: timer.kitchen_tea
+  defaultPreset: Black Tea
+  presets:
+    - label: Green Tea
+      durationSeconds: 120
+    - label: Oolong Tea
+      durationSeconds: 180
+    - label: Black Tea
+      durationSeconds: 240
+  minDurationSeconds: 30
+  maxDurationSeconds: 900
+  stepSeconds: 5
+  finishedAutoIdleMs: 5000

--- a/examples/lovelace/tea-timer-card-two-timers.yaml
+++ b/examples/lovelace/tea-timer-card-two-timers.yaml
@@ -1,0 +1,25 @@
+# Two Tea Timer Cards sharing presets but targeting different entities.
+# Replace the entity ids with your timer helpers.
+
+- type: custom:tea-timer-card
+  title: Kitchen Tea Timer
+  entity: timer.kitchen_tea
+  presets: &tea_presets
+    - label: Green Tea
+      durationSeconds: 120
+    - label: Black Tea
+      durationSeconds: 240
+    - label: Herbal Blend
+      durationSeconds: 300
+  defaultPreset: Green Tea
+  minDurationSeconds: 30
+  maxDurationSeconds: 1200
+  stepSeconds: 5
+
+- type: custom:tea-timer-card
+  title: Living Room Tea Timer
+  entity: timer.living_room_tea
+  presets: *tea_presets
+  defaultPreset: Herbal Blend
+  confirmRestart: true
+  finishedAutoIdleMs: 7000

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,13 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "cspell": "^8.19.4",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "jsdom": "^24.0.0",
+        "linkinator": "^4.1.3",
         "lit": "^3.1.0",
+        "markdownlint-cli": "^0.39.0",
         "typescript": "5.3.3",
         "vite": "^5.1.6",
         "vitest": "^1.4.0"
@@ -46,6 +49,626 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.19.4.tgz",
+      "integrity": "sha512-2ZRcZP/ncJ5q953o8i+R0fb8+14PDt5UefUNMrFZZHvfTI0jukAASOQeLY+WT6ASZv6CgbPrApAdbppy9FaXYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-ada": "^4.1.0",
+        "@cspell/dict-al": "^1.1.0",
+        "@cspell/dict-aws": "^4.0.10",
+        "@cspell/dict-bash": "^4.2.0",
+        "@cspell/dict-companies": "^3.1.15",
+        "@cspell/dict-cpp": "^6.0.8",
+        "@cspell/dict-cryptocurrencies": "^5.0.4",
+        "@cspell/dict-csharp": "^4.0.6",
+        "@cspell/dict-css": "^4.0.17",
+        "@cspell/dict-dart": "^2.3.0",
+        "@cspell/dict-data-science": "^2.0.8",
+        "@cspell/dict-django": "^4.1.4",
+        "@cspell/dict-docker": "^1.1.13",
+        "@cspell/dict-dotnet": "^5.0.9",
+        "@cspell/dict-elixir": "^4.0.7",
+        "@cspell/dict-en_us": "^4.4.3",
+        "@cspell/dict-en-common-misspellings": "^2.0.10",
+        "@cspell/dict-en-gb": "1.1.33",
+        "@cspell/dict-filetypes": "^3.0.11",
+        "@cspell/dict-flutter": "^1.1.0",
+        "@cspell/dict-fonts": "^4.0.4",
+        "@cspell/dict-fsharp": "^1.1.0",
+        "@cspell/dict-fullstack": "^3.2.6",
+        "@cspell/dict-gaming-terms": "^1.1.1",
+        "@cspell/dict-git": "^3.0.4",
+        "@cspell/dict-golang": "^6.0.20",
+        "@cspell/dict-google": "^1.0.8",
+        "@cspell/dict-haskell": "^4.0.5",
+        "@cspell/dict-html": "^4.0.11",
+        "@cspell/dict-html-symbol-entities": "^4.0.3",
+        "@cspell/dict-java": "^5.0.11",
+        "@cspell/dict-julia": "^1.1.0",
+        "@cspell/dict-k8s": "^1.0.10",
+        "@cspell/dict-kotlin": "^1.1.0",
+        "@cspell/dict-latex": "^4.0.3",
+        "@cspell/dict-lorem-ipsum": "^4.0.4",
+        "@cspell/dict-lua": "^4.0.7",
+        "@cspell/dict-makefile": "^1.0.4",
+        "@cspell/dict-markdown": "^2.0.10",
+        "@cspell/dict-monkeyc": "^1.0.10",
+        "@cspell/dict-node": "^5.0.7",
+        "@cspell/dict-npm": "^5.2.1",
+        "@cspell/dict-php": "^4.0.14",
+        "@cspell/dict-powershell": "^5.0.14",
+        "@cspell/dict-public-licenses": "^2.0.13",
+        "@cspell/dict-python": "^4.2.17",
+        "@cspell/dict-r": "^2.1.0",
+        "@cspell/dict-ruby": "^5.0.8",
+        "@cspell/dict-rust": "^4.0.11",
+        "@cspell/dict-scala": "^5.0.7",
+        "@cspell/dict-shell": "^1.1.0",
+        "@cspell/dict-software-terms": "^5.0.5",
+        "@cspell/dict-sql": "^2.2.0",
+        "@cspell/dict-svelte": "^1.0.6",
+        "@cspell/dict-swift": "^2.0.5",
+        "@cspell/dict-terraform": "^1.1.1",
+        "@cspell/dict-typescript": "^3.2.1",
+        "@cspell/dict-vue": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-json-reporter": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.19.4.tgz",
+      "integrity": "sha512-pOlUtLUmuDdTIOhDTvWxxta0Wm8RCD/p1V0qUqeP6/Ups1ajBI4FWEpRFd7yMBTUHeGeSNicJX5XeX7wNbAbLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "8.19.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-pipe": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.19.4.tgz",
+      "integrity": "sha512-GNAyk+7ZLEcL2fCMT5KKZprcdsq3L1eYy3e38/tIeXfbZS7Sd1R5FXUe6CHXphVWTItV39TvtLiDwN/2jBts9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-resolver": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.19.4.tgz",
+      "integrity": "sha512-S8vJMYlsx0S1D60glX8H2Jbj4mD8519VjyY8lu3fnhjxfsl2bDFZvF3ZHKsLEhBE+Wh87uLqJDUJQiYmevHjDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-service-bus": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.19.4.tgz",
+      "integrity": "sha512-uhY+v8z5JiUogizXW2Ft/gQf3eWrh5P9036jN2Dm0UiwEopG/PLshHcDjRDUiPdlihvA0RovrF0wDh4ptcrjuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.19.4.tgz",
+      "integrity": "sha512-ekMWuNlFiVGfsKhfj4nmc8JCA+1ZltwJgxiKgDuwYtR09ie340RfXFF6YRd2VTW5zN7l4F1PfaAaPklVz6utSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
+      "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-al": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
+      "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.15.tgz",
+      "integrity": "sha512-aPY7VVR5Os4rz36EaqXBAEy14wR4Rqv+leCJ2Ug/Gd0IglJpM30LalF3e2eJChnjje3vWoEC0Rz3+e5gpZG+Kg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.2.1.tgz",
+      "integrity": "sha512-SBnzfAyEAZLI9KFS7DUG6Xc1vDFuLllY3jz0WHvmxe8/4xV3ufFE3fGxalTikc1VVeZgZmxYiABw4iGxVldYEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-shell": "1.1.1"
+      }
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.5.tgz",
+      "integrity": "sha512-H51R0w7c6RwJJPqH7Gs65tzP6ouZsYDEHmmol6MIIk0kQaOIBuFP2B3vIxHLUr2EPRVFZsMW8Ni7NmVyaQlwsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.12.tgz",
+      "integrity": "sha512-N4NsCTttVpMqQEYbf0VQwCj6np+pJESov0WieCN7R/0aByz4+MXEiDieWWisaiVi8LbKzs1mEj4ZTw5K/6O2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.5.tgz",
+      "integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.7.tgz",
+      "integrity": "sha512-H16Hpu8O/1/lgijFt2lOk4/nnldFtQ4t8QHbyqphqZZVE5aS4J/zD/WvduqnLY21aKhZS6jo/xF5PX9jyqPKUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.18.tgz",
+      "integrity": "sha512-EF77RqROHL+4LhMGW5NTeKqfUd/e4OOv6EDFQ/UQQiFyWuqkEKyEz0NDILxOFxWUEVdjT2GQ2cC7t12B6pESwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dart": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.1.tgz",
+      "integrity": "sha512-xoiGnULEcWdodXI6EwVyqpZmpOoh8RA2Xk9BNdR7DLamV/QMvEYn8KJ7NlRiTSauJKPNkHHQ5EVHRM6sTS7jdg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-data-science": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.9.tgz",
+      "integrity": "sha512-wTOFMlxv06veIwKdXUwdGxrQcK44Zqs426m6JGgHIB/GqvieZQC5n0UI+tUm5OCxuNyo4OV6mylT4cRMjtKtWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.5.tgz",
+      "integrity": "sha512-AvTWu99doU3T8ifoMYOMLW2CXKvyKLukPh1auOPwFGHzueWYvBBN+OxF8wF7XwjTBMMeRleVdLh3aWCDEX/ZWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-docker": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.16.tgz",
+      "integrity": "sha512-UiVQ5RmCg6j0qGIxrBnai3pIB+aYKL3zaJGvXk1O/ertTKJif9RZikKXCEgqhaCYMweM4fuLqWSVmw3hU164Iw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.10.tgz",
+      "integrity": "sha512-ooar8BP/RBNP1gzYfJPStKEmpWy4uv/7JCq6FOnJLeD1yyfG3d/LFMVMwiJo+XWz025cxtkM3wuaikBWzCqkmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
+      "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.19.tgz",
+      "integrity": "sha512-JYYgzhGqSGuIMNY1cTlmq3zrNpehrExMHqLmLnSM2jEGFeHydlL+KLBwBYxMy4e73w+p1+o/rmAiGsMj9g3MCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en-common-misspellings": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.6.tgz",
+      "integrity": "sha512-xV9yryOqZizbSqxRS7kSVRrxVEyWHUqwdY56IuT7eAWGyTCJNmitXzXa4p+AnEbhL+AB2WLynGVSbNoUC3ceFA==",
+      "dev": true,
+      "license": "CC BY-SA 4.0"
+    },
+    "node_modules/@cspell/dict-en-gb": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
+      "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.13.tgz",
+      "integrity": "sha512-g6rnytIpQlMNKGJT1JKzWkC+b3xCliDKpQ3ANFSq++MnR4GaLiifaC4JkVON11Oh/UTplYOR1nY3BR4X30bswA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-flutter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
+      "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.5.tgz",
+      "integrity": "sha512-BbpkX10DUX/xzHs6lb7yzDf/LPjwYIBJHJlUXSBXDtK/1HaeS+Wqol4Mlm2+NAgZ7ikIE5DQMViTgBUY3ezNoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fsharp": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
+      "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.7.tgz",
+      "integrity": "sha512-IxEk2YAwAJKYCUEgEeOg3QvTL4XLlyArJElFuMQevU1dPgHgzWElFevN5lsTFnvMFA1riYsVinqJJX0BanCFEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-gaming-terms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.2.tgz",
+      "integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-git": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.7.tgz",
+      "integrity": "sha512-odOwVKgfxCQfiSb+nblQZc4ErXmnWEnv8XwkaI4sNJ7cNmojnvogYVeMqkXPjvfrgEcizEEA4URRD2Ms5PDk1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "6.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.23.tgz",
+      "integrity": "sha512-oXqUh/9dDwcmVlfUF5bn3fYFqbUzC46lXFQmi5emB0vYsyQXdNWsqi6/yH3uE7bdRE21nP7Yo0mR1jjFNyLamg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-google": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
+      "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
+      "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.12.tgz",
+      "integrity": "sha512-JFffQ1dDVEyJq6tCDWv0r/RqkdSnV43P2F/3jJ9rwLgdsOIXwQbXrz6QDlvQLVvNSnORH9KjDtenFTGDyzfCaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.4.tgz",
+      "integrity": "sha512-afea+0rGPDeOV9gdO06UW183Qg6wRhWVkgCFwiO3bDupAoyXRuvupbb5nUyqSTsLXIKL8u8uXQlJ9pkz07oVXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
+      "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-julia": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
+      "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-k8s": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.12.tgz",
+      "integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-kotlin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
+      "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.4.tgz",
+      "integrity": "sha512-YdTQhnTINEEm/LZgTzr9Voz4mzdOXH7YX+bSFs3hnkUHCUUtX/mhKgf1CFvZ0YNM2afjhQcmLaR9bDQVyYBvpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.5.tgz",
+      "integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
+      "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-makefile": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
+      "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-markdown": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.12.tgz",
+      "integrity": "sha512-ufwoliPijAgWkD/ivAMC+A9QD895xKiJRF/fwwknQb7kt7NozTLKFAOBtXGPJAB4UjhGBpYEJVo2elQ0FCAH9A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cspell/dict-css": "^4.0.18",
+        "@cspell/dict-html": "^4.0.12",
+        "@cspell/dict-html-symbol-entities": "^4.0.4",
+        "@cspell/dict-typescript": "^3.2.3"
+      }
+    },
+    "node_modules/@cspell/dict-monkeyc": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.11.tgz",
+      "integrity": "sha512-7Q1Ncu0urALI6dPTrEbSTd//UK0qjRBeaxhnm8uY5fgYNFYAG+u4gtnTIo59S6Bw5P++4H3DiIDYoQdY/lha8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.8.tgz",
+      "integrity": "sha512-AirZcN2i84ynev3p2/1NCPEhnNsHKMz9zciTngGoqpdItUb2bDt1nJBjwlsrFI78GZRph/VaqTVFwYikmncpXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "5.2.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.17.tgz",
+      "integrity": "sha512-0yp7lBXtN3CtxBrpvTu/yAuPdOHR2ucKzPxdppc3VKO068waZNpKikn1NZCzBS3dIAFGVITzUPtuTXxt9cxnSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.15.tgz",
+      "integrity": "sha512-iepGB2gtToMWSTvybesn4/lUp4LwXcEm0s8vasJLP76WWVkq1zYjmeS+WAIzNgsuURyZ/9mGqhS0CWMuo74ODw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
+      "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-public-licenses": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.15.tgz",
+      "integrity": "sha512-cJEOs901H13Pfy0fl4dCD1U+xpWIMaEPq8MeYU83FfDZvellAuSo4GqWCripfIqlhns/L6+UZEIJSOZnjgy7Wg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.19.tgz",
+      "integrity": "sha512-9S2gTlgILp1eb6OJcVZeC8/Od83N8EqBSg5WHVpx97eMMJhifOzePkE0kDYjyHMtAFznCQTUu0iQEJohNQ5B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-data-science": "^2.0.9"
+      }
+    },
+    "node_modules/@cspell/dict-r": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
+      "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.9.tgz",
+      "integrity": "sha512-H2vMcERMcANvQshAdrVx0XoWaNX8zmmiQN11dZZTQAZaNJ0xatdJoSqY8C8uhEMW89bfgpN+NQgGuDXW2vmXEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.12.tgz",
+      "integrity": "sha512-z2QiH+q9UlNhobBJArvILRxV8Jz0pKIK7gqu4TgmEYyjiu1TvnGZ1tbYHeu9w3I/wOP6UMDoCBTty5AlYfW0mw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.8.tgz",
+      "integrity": "sha512-YdftVmumv8IZq9zu1gn2U7A4bfM2yj9Vaupydotyjuc+EEZZSqAafTpvW/jKLWji2TgybM1L2IhmV0s/Iv9BTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-shell": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.1.1.tgz",
+      "integrity": "sha512-T37oYxE7OV1x/1D4/13Y8JZGa1QgDCXV7AVt3HLXjn0Fe3TaNDvf5sU0fGnXKmBPqFFrHdpD3uutAQb1dlp15g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.8.tgz",
+      "integrity": "sha512-iwCHLP11OmVHEX2MzE8EPxpPw7BelvldxWe5cJ3xXIDL8TjF2dBTs2noGcrqnZi15SLYIlO8897BIOa33WHHZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-sql": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
+      "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-svelte": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
+      "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-swift": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
+      "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-terraform": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.3.tgz",
+      "integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
+      "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-vue": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
+      "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dynamic-import": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.19.4.tgz",
+      "integrity": "sha512-0LLghC64+SiwQS20Sa0VfFUBPVia1rNyo0bYeIDoB34AA3qwguDBVJJkthkpmaP1R2JeR/VmxmJowuARc4ZUxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "8.19.4",
+        "import-meta-resolve": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@cspell/filetypes": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.19.4.tgz",
+      "integrity": "sha512-D9hOCMyfKtKjjqQJB8F80PWsjCZhVGCGUMiDoQpcta0e+Zl8vHgzwaC0Ai4QUGBhwYEawHGiWUd7Y05u/WXiNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.19.4.tgz",
+      "integrity": "sha512-MUfFaYD8YqVe32SQaYLI24/bNzaoyhdBIFY5pVrvMo1ZCvMl8AlfI2OcBXvcGb5aS5z7sCNCJm11UuoYbLI1zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/url": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.19.4.tgz",
+      "integrity": "sha512-Pa474iBxS+lxsAL4XkETPGIq3EgMLCEb9agj3hAd2VGMTCApaiUvamR4b+uGXIPybN70piFxvzrfoxsG2uIP6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -703,6 +1326,53 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -776,6 +1446,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1124,6 +1805,20 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1555,6 +2250,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1563,6 +2265,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/assertion-error": {
@@ -1646,6 +2358,51 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
+      "integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^7.0.0",
+        "map-obj": "^4.3.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^2.13.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -1682,6 +2439,35 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -1693,6 +2479,46 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/clear-module": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clear-module/node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clear-module/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -1728,6 +2554,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/comment-json": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.4.1.tgz",
+      "integrity": "sha512-r1To31BQD5060QdkC+Iheai7gHwoSZobzunqkf2/kQ6xIAfJyrKNAFUwdKvkK7Qgu7pVTKQEa7ok7Ed3ycAJgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1739,6 +2590,13 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1755,6 +2613,250 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.19.4.tgz",
+      "integrity": "sha512-toaLrLj3usWY0Bvdi661zMmpKW2DVLAG3tcwkAv4JBTisdIRn15kN/qZDrhSieUEhVgJgZJDH4UKRiq29mIFxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-json-reporter": "8.19.4",
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "@cspell/dynamic-import": "8.19.4",
+        "@cspell/url": "8.19.4",
+        "chalk": "^5.4.1",
+        "chalk-template": "^1.1.0",
+        "commander": "^13.1.0",
+        "cspell-dictionary": "8.19.4",
+        "cspell-gitignore": "8.19.4",
+        "cspell-glob": "8.19.4",
+        "cspell-io": "8.19.4",
+        "cspell-lib": "8.19.4",
+        "fast-json-stable-stringify": "^2.1.0",
+        "file-entry-cache": "^9.1.0",
+        "semver": "^7.7.1",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "cspell": "bin.mjs",
+        "cspell-esm": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-config-lib": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.19.4.tgz",
+      "integrity": "sha512-LtFNZEWVrnpjiTNgEDsVN05UqhhJ1iA0HnTv4jsascPehlaUYVoyucgNbFeRs6UMaClJnqR0qT9lnPX+KO1OLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "8.19.4",
+        "comment-json": "^4.2.5",
+        "yaml": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-dictionary": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.19.4.tgz",
+      "integrity": "sha512-lr8uIm7Wub8ToRXO9f6f7in429P1Egm3I+Ps3ZGfWpwLTCUBnHvJdNF/kQqF7PL0Lw6acXcjVWFYT7l2Wdst2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "cspell-trie-lib": "8.19.4",
+        "fast-equals": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-gitignore": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.19.4.tgz",
+      "integrity": "sha512-KrViypPilNUHWZkMV0SM8P9EQVIyH8HvUqFscI7+cyzWnlglvzqDdV4N5f+Ax5mK+IqR6rTEX8JZbCwIWWV7og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "8.19.4",
+        "cspell-glob": "8.19.4",
+        "cspell-io": "8.19.4"
+      },
+      "bin": {
+        "cspell-gitignore": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.19.4.tgz",
+      "integrity": "sha512-042uDU+RjAz882w+DXKuYxI2rrgVPfRQDYvIQvUrY1hexH4sHbne78+OMlFjjzOCEAgyjnm1ktWUCCmh08pQUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "8.19.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-glob/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/cspell-grammar": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.19.4.tgz",
+      "integrity": "sha512-lzWgZYTu/L7DNOHjxuKf8H7DCXvraHMKxtFObf8bAzgT+aBmey5fW2LviXUkZ2Lb2R0qQY+TJ5VIGoEjNf55ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4"
+      },
+      "bin": {
+        "cspell-grammar": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.19.4.tgz",
+      "integrity": "sha512-W48egJqZ2saEhPWf5ftyighvm4mztxEOi45ILsKgFikXcWFs0H0/hLwqVFeDurgELSzprr12b6dXsr67dV8amg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-service-bus": "8.19.4",
+        "@cspell/url": "8.19.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.19.4.tgz",
+      "integrity": "sha512-NwfdCCYtIBNQuZcoMlMmL3HSv2olXNErMi/aOTI9BBAjvCHjhgX5hbHySMZ0NFNynnN+Mlbu5kooJ5asZeB3KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "8.19.4",
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-resolver": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "@cspell/dynamic-import": "8.19.4",
+        "@cspell/filetypes": "8.19.4",
+        "@cspell/strong-weak-map": "8.19.4",
+        "@cspell/url": "8.19.4",
+        "clear-module": "^4.1.2",
+        "comment-json": "^4.2.5",
+        "cspell-config-lib": "8.19.4",
+        "cspell-dictionary": "8.19.4",
+        "cspell-glob": "8.19.4",
+        "cspell-grammar": "8.19.4",
+        "cspell-io": "8.19.4",
+        "cspell-trie-lib": "8.19.4",
+        "env-paths": "^3.0.0",
+        "fast-equals": "^5.2.2",
+        "gensequence": "^7.0.0",
+        "import-fresh": "^3.3.1",
+        "resolve-from": "^5.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-lib/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.19.4.tgz",
+      "integrity": "sha512-yIPlmGSP3tT3j8Nmu+7CNpkPh/gBO2ovdnqNmZV+LNtQmVxqFd2fH7XvR1TKjQyctSH1ip0P5uIdJmzY1uhaYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "gensequence": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cspell/node_modules/file-entry-cache": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
+      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell/node_modules/flat-cache": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.3.1",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/css.escape": {
@@ -1817,6 +2919,56 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -1835,6 +2987,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -1897,6 +3059,78 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1912,6 +3146,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1923,6 +3171,29 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -2012,6 +3283,13 @@
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2168,6 +3446,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -2248,12 +3540,29 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.2.tgz",
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2374,6 +3683,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -2423,6 +3749,72 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gaxios/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gensequence": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
+      "integrity": "sha512-47Frx13aZh01afHJTB3zTtKIlFI6vWY+MYCN9Qpew6i52rfKjnhCF/l1YlC8UmEMvvntZZ6z4PiCcmyuedR2aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -2470,6 +3862,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -2544,6 +3949,22 @@
         "node": "*"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -2601,6 +4022,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2653,6 +4084,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+      "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -2664,6 +4118,39 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2744,6 +4231,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2783,6 +4281,39 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2791,6 +4322,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2826,6 +4367,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -2852,6 +4403,22 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -2921,6 +4488,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2935,6 +4509,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2943,6 +4524,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -2957,6 +4548,96 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkinator": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-4.1.3.tgz",
+      "integrity": "sha512-jlpUQeqT3c+oo5Kk8v50NUwycV9JDNj029EmwFBk2Qfa3A9tz2+JyMCB3zQ9D9xR56tC/KNmQkzyGQR0qPCCdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "escape-html": "^1.0.3",
+        "gaxios": "^5.0.0",
+        "glob": "^9.3.2",
+        "htmlparser2": "^9.0.0",
+        "marked": "^4.0.3",
+        "meow": "^11.0.0",
+        "mime": "^3.0.0",
+        "server-destroy": "^1.0.1",
+        "srcset": "^5.0.0"
+      },
+      "bin": {
+        "linkinator": "build/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/linkinator/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/linkinator/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/linkinator/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/lit": {
@@ -3060,6 +4741,160 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
+      "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.33.0.tgz",
+      "integrity": "sha512-4lbtT14A3m0LPX1WS/3d1m7Blg+ZwiLq36WvjQqFGsX3Gik99NV+VXp/PW3n+Q62xyPdbvGOCfjPqjW+/SKMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "markdown-it": "14.0.0",
+        "markdownlint-micromark": "0.1.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.39.0.tgz",
+      "integrity": "sha512-ZuFN7Xpsbn1Nbp0YYkeLOfXOMOfLQBik2lKRy8pVI/llmKQ2uW7x+8k5OMgF6o7XCsTDSYC/OOmeJ+3qplvnJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "~11.1.0",
+        "get-stdin": "~9.0.0",
+        "glob": "~10.3.10",
+        "ignore": "~5.3.0",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "~3.2.1",
+        "markdownlint": "~0.33.0",
+        "minimatch": "~9.0.3",
+        "run-con": "~1.3.2"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/glob": {
+      "version": "10.3.16",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.16.tgz",
+      "integrity": "sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.1",
+        "minipass": "^7.0.4",
+        "path-scurry": "^1.11.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/markdownlint-micromark": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.8.tgz",
+      "integrity": "sha512-1ouYkMRo9/6gou9gObuMDnvZM8jC/ly3QCFQyoSPCS2XV1ZClU0xpKbL1Ar3bWWRT1RnBZkWUEiNKrI2CwiBQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3068,6 +4903,96 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meow": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
+      "integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^8.0.2",
+        "decamelize": "^6.0.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^4.0.1",
+        "read-pkg-up": "^9.1.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^3.1.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/redent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/strip-indent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.0.tgz",
+      "integrity": "sha512-OA95x+JPmL7kc7zCu+e+TeYxEiaIyndRx0OrBcK2QPPH09oAndr2ALvymxWA+Lx1PYYvFUm4O63pRkdJAaW96w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -3099,6 +5024,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -3163,6 +5101,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -3215,6 +5188,68 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
+      "integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -3341,6 +5376,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3382,6 +5436,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -3540,6 +5621,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -3568,12 +5659,218 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/read-pkg": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
+      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
+      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0",
+        "read-pkg": "^7.1.0",
+        "type-fest": "^2.5.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/read-pkg/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -3683,6 +5980,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/run-con": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~4.1.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3739,6 +6052,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3803,6 +6123,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/srcset": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.2.tgz",
+      "integrity": "sha512-pucR5KmXL7uWI59sXE2nuodomLsfnIQDa5Fck0TooiyxsIx+JYGiFm+wFO7aaDvvl/43ipjUjAb5je7dcAwlzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3817,7 +6186,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3916,6 +6369,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
@@ -3976,6 +6477,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+      "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4047,6 +6561,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
@@ -4083,6 +6604,17 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vite": {
@@ -4234,6 +6766,20 @@
         }
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -4337,6 +6883,107 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4366,6 +7013,19 @@
         }
       }
     },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4382,6 +7042,36 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "start": "vite dev",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint:markdown": "markdownlint \"docs/**/*.md\" README.md",
+    "lint:spell": "cspell \"docs/**/*.md\" \"README.md\"",
+    "lint:links": "linkinator 'docs/**/*.md' README.md --recurse --silent --skip 'http://localhost:5173/' --skip 'https://hacs.xyz/*' --skip 'https://www.home-assistant.io/*'",
+    "docs:check": "npm run lint:markdown && npm run lint:spell && npm run lint:links"
   },
   "keywords": [
     "home-assistant",
@@ -33,10 +37,13 @@
     "@testing-library/jest-dom": "^6.4.2",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "cspell": "^8.19.4",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "jsdom": "^24.0.0",
+    "linkinator": "^4.1.3",
     "lit": "^3.1.0",
+    "markdownlint-cli": "^0.39.0",
     "typescript": "5.3.3",
     "vite": "^5.1.6",
     "vitest": "^1.4.0"


### PR DESCRIPTION
## Summary
- Documented quick start, configuration reference, state flows, multi-instance sync, accessibility, troubleshooting, FAQ, contributing, and changelog pages under `docs/` in Markdown per Issue #11 structure.
- Added Home Assistant Lovelace and automation YAML examples to `examples/` for single and dual timer setups.
- Added markdownlint, cspell, and linkinator scripts plus CI workflow to enforce docs quality.

## Acceptance Criteria
- [x] README links to docs quick start and other guides (`README.md`)
- [x] Quick-start guide enables timer setup with finished overlay validation (`docs/quick-start.md`)
- [x] Configuration reference defines options with defaults and examples (`docs/configuration-reference.md`)
- [x] Automations guide attaches to `timer.finished` and notes missed finishes (`docs/automations/finished.md`)
- [x] Examples folder provides single/dual timer card configs and automation YAML (`examples/`)
- [x] Troubleshooting covers entity, connection, updates, drift, availability, automation failures (`docs/troubleshooting.md`)
- [x] Docs lint/spell/link checks run via npm scripts and workflow (`package.json`, `.github/workflows/docs.yml`)
- [x] Accessibility, state/actions, multi-instance sync, etc. documented to match behavior (`docs/state-and-actions.md`, `docs/accessibility-and-reduced-motion.md`, `docs/multi-instance-and-sync.md`)

## Risks & Rollback
- Docs may drift from behavior; docs-check workflow and npm scripts mitigate by keeping links/spelling valid.
- Rollback by reverting this commit to remove new docs and CI workflow in a single revert.

## Follow-ups / Open Questions
- Gather community brew duration recommendations for a future “best brew times” appendix.
- Consider adding issue templates for documentation requests once feedback arrives.

------
https://chatgpt.com/codex/tasks/task_e_68e03054fe30833389ad903a3d961e19