### PR TITLE
[cleanup] Remove preview banner & inline docs; add Editor Help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Hide the dial handle while the timer is running or paused to reinforce the locked state. (#34)
+- Clean up preliminary UI; docs via Editor Help (#44)
 
 ### Fixed
 - Prevent idle dial drags from triggering `timer.start`; releasing a drag now leaves the timer idle

--- a/src/card/TeaTimerCard.test.ts
+++ b/src/card/TeaTimerCard.test.ts
@@ -1665,18 +1665,22 @@ describe("TeaTimerCard", () => {
     expect(emptyState?.textContent).toBe(STRINGS.presetsMissing);
   });
 
-  it("renders support links for setup and automations", () => {
+  it("does not render preview banners or inline documentation links", async () => {
     const card = createCard();
+    document.body.appendChild(card);
     card.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle" });
     setTimerState(card, { status: "idle" });
 
-    const linksTemplate = (card as unknown as { _renderSupportLinks(): TemplateResult })._renderSupportLinks();
-    const container = document.createElement("div");
-    render(linksTemplate, container);
-    const links = Array.from(container.querySelectorAll<HTMLAnchorElement>(".links .help"));
-    expect(links.length).toBe(2);
-    const labels = links.map((link) => link.textContent?.trim());
-    expect(labels).toEqual([STRINGS.gettingStartedLabel, STRINGS.finishAutomationLabel]);
+    await card.updateComplete;
+
+    const shadow = card.shadowRoot;
+    expect(shadow?.querySelector(".note")).toBeNull();
+    const textContent = shadow?.textContent ?? "";
+    expect(textContent).not.toContain("This is a preview of the Tea Timer Card");
+    expect(textContent).not.toContain("Getting Started");
+    expect(textContent).not.toContain("Automate timer finish");
+    expect(textContent).not.toContain("Quick start guide");
+    expect(textContent).not.toContain("Automate on timer.finished");
   });
 
   it("pauses via helper when native pause is unavailable", async () => {

--- a/src/card/TeaTimerCard.ts
+++ b/src/card/TeaTimerCard.ts
@@ -259,8 +259,6 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
         </div>
         ${state ? this._renderPrimaryAction(state) : nothing}
         <div class="sr-only" role="status" aria-live="polite">${this._ariaAnnouncement}</div>
-        <p class="note">${STRINGS.draftNote}</p>
-        ${this._renderSupportLinks()}
         ${this._renderPendingOverlay(state)}
         ${this._confirmRestartVisible ? this._renderRestartConfirm() : nothing}
         ${this._renderToast()}
@@ -284,19 +282,6 @@ export class TeaTimerCard extends LitElement implements LovelaceCard {
     }
 
     this._scheduleApplyDialDisplay("first-updated");
-  }
-
-  private _renderSupportLinks() {
-    return html`
-      <div class="links">
-        <a class="help" href=${STRINGS.gettingStartedUrl} target="_blank" rel="noreferrer">
-          ${STRINGS.gettingStartedLabel}
-        </a>
-        <a class="help" href=${STRINGS.finishAutomationUrl} target="_blank" rel="noreferrer">
-          ${STRINGS.finishAutomationLabel}
-        </a>
-      </div>
-    `;
   }
 
   private _announce(message: string | undefined): void {

--- a/src/editor/tea-timer-card-editor.test.ts
+++ b/src/editor/tea-timer-card-editor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import "./tea-timer-card-editor";
+
+describe("tea-timer-card-editor", () => {
+  const tagName = "tea-timer-card-editor";
+
+  it("surfaces documentation links in the help footer", async () => {
+    const editor = document.createElement(tagName);
+    document.body.appendChild(editor);
+    editor.setConfig({ type: "custom:tea-timer-card", entity: "timer.kettle", presets: [] });
+
+    await editor.updateComplete;
+
+    const help = editor.shadowRoot?.querySelector(".editor-help");
+    expect(help).toBeTruthy();
+    const links = Array.from(help?.querySelectorAll<HTMLAnchorElement>("a") ?? []);
+    expect(links.map((link) => link.textContent?.trim())).toEqual([
+      "Quick start guide",
+      "Automate on timer.finished",
+    ]);
+    expect(links.every((link) => link.target === "_blank")).toBe(true);
+    expect(links.every((link) => link.rel.includes("noreferrer"))).toBe(true);
+
+    editor.remove();
+  });
+});

--- a/src/editor/tea-timer-card-editor.ts
+++ b/src/editor/tea-timer-card-editor.ts
@@ -37,6 +37,19 @@ const HELPERS: Record<string, string> = {
   finishedAutoIdleMs: "Delay before returning to idle after the finished overlay appears. Defaults to 5000 ms.",
 };
 
+const DOCUMENTATION_LINKS = [
+  {
+    label: "Quick start guide",
+    href: "https://github.com/sharwell/ha-tea-timer/blob/main/docs/getting-started.md",
+    ariaLabel: "Open the quick start guide in a new tab",
+  },
+  {
+    label: "Automate on timer.finished",
+    href: "https://github.com/sharwell/ha-tea-timer/blob/main/docs/automations/finished.md",
+    ariaLabel: "Open the automate on timer.finished guide in a new tab",
+  },
+] as const;
+
 @customElement("tea-timer-card-editor")
 export class TeaTimerCardEditor
   extends LitElement
@@ -134,6 +147,26 @@ export class TeaTimerCardEditor
     .advanced-content {
       margin-top: 12px;
     }
+
+    .editor-help {
+      margin-top: 24px;
+      padding-top: 16px;
+      border-top: 1px solid var(--divider-color, #bdbdbd);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      font-size: 0.9rem;
+    }
+
+    .editor-help-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .editor-help a {
+      color: var(--primary-color);
+    }
   `;
 
   @property({ attribute: false }) public hass?: HomeAssistant;
@@ -197,6 +230,24 @@ export class TeaTimerCardEditor
           ></ha-form>
         </div>
       </details>
+
+      <footer class="editor-help">
+        <span id="documentation-links-heading">Documentation</span>
+        <div class="editor-help-links" aria-labelledby="documentation-links-heading">
+          ${DOCUMENTATION_LINKS.map(
+            (link) => html`
+              <a
+                href=${link.href}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="${link.ariaLabel} (opens in new tab)"
+              >
+                ${link.label}
+              </a>
+            `,
+          )}
+        </div>
+      </footer>
     `;
   }
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -2,11 +2,6 @@ export interface StringTable {
   cardTitleFallback: string;
   emptyState: string;
   missingEntity: string;
-  draftNote: string;
-  gettingStartedLabel: string;
-  gettingStartedUrl: string;
-  finishAutomationLabel: string;
-  finishAutomationUrl: string;
   presetsGroupLabel: string;
   presetsMissing: string;
   presetsCustomLabel: string;
@@ -103,11 +98,6 @@ export const STRINGS: StringTable = {
   cardTitleFallback: "Tea Timer",
   emptyState: "Configure an entity and presets to get started.",
   missingEntity: "Timer entity not configured.",
-  draftNote: "This is a preview of the Tea Timer Card. Functionality will be enabled in upcoming updates.",
-  gettingStartedLabel: "Getting Started",
-  gettingStartedUrl: "https://github.com/sharwell/ha-tea-timer/blob/main/docs/getting-started.md",
-  finishAutomationLabel: "Automate timer finish",
-  finishAutomationUrl: "https://github.com/sharwell/ha-tea-timer/blob/main/docs/automations/finished.md",
   presetsGroupLabel: "Presets",
   presetsMissing: "Add at least one preset to start brewing.",
   presetsCustomLabel: "Custom duration",

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -308,23 +308,6 @@ export const cardStyles = css`
     color: var(--secondary-text-color, #52606d);
   }
 
-  .note {
-    font-size: 0.75rem;
-    color: var(--secondary-text-color, #52606d);
-    margin: 0;
-  }
-
-  .links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    align-items: center;
-  }
-
-  .help {
-    font-size: 0.85rem;
-  }
-
   .errors {
     margin: 0 0 12px;
     padding: 12px;


### PR DESCRIPTION
## Summary
- remove the preview banner and inline documentation links from the runtime Tea Timer card, including unused strings and styles
- add a documentation footer to the visual editor with quick-start and automation links that open in a new tab
- cover the new UX with tests that assert the card stays clean and the editor exposes the help entry point

Closes #44

## Testing
- npm test
- npm run lint
- npm run typecheck
- npm run build
- rg "This is a preview of the Tea Timer Card" dist
- rg "Getting Started" dist/tea-timer-card.js dist/tea-timer-card.*.js
- rg "Automate timer finish" dist/tea-timer-card.js dist/tea-timer-card.*.js

## Acceptance Criteria
- [x] No provisional UI at runtime — covered by updated TeaTimerCard render test and manual dist inspection
- [x] Dist artifact check — the literal preview/banner strings no longer appear in the built bundles (see grep commands above)
- [x] Editor Help present — new editor test ensures the footer renders both doc links
- [x] YAML mode preserved — no schema changes
- [x] Demo-only allowance — demo untouched
- [x] No behavior regression — existing smoke/unit tests continue to pass

## Risks & Rollback
- Low risk: revert this commit to restore the previous runtime banner/links
- If the editor footer needs to be hidden temporarily, remove the footer section in `tea-timer-card-editor.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e467f061688333ad880fc4f7b45ecd