### PR TITLE
[ux] Consolidate entity error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Hide the dial handle while the timer is running or paused to reinforce the locked state. (#34)
 - Clean up preliminary UI; docs via Editor Help (#44)
+- Consolidate timer-entity errors into a single alert surface with clear precedence over secondary hints. (#38)
 
 ### Fixed
 - Prevent idle dial drags from triggering `timer.start`; releasing a drag now leaves the timer idle

--- a/demo/index.html
+++ b/demo/index.html
@@ -174,6 +174,10 @@
       <button type="button" id="btn-pause">Set paused (1:30)</button>
       <button type="button" id="btn-finish">Emit finished event</button>
       <button type="button" id="btn-unavailable">Mark unavailable</button>
+      <button type="button" id="btn-missing-entity">Simulate missing entity</button>
+      <button type="button" id="btn-wrong-domain">Simulate wrong domain</button>
+      <button type="button" id="btn-unknown-entity">Simulate unknown id</button>
+      <button type="button" id="btn-reset-entity">Restore timer entity</button>
       <button type="button" id="btn-disconnect">Disconnect</button>
       <button type="button" id="btn-reconnect">Reconnect</button>
       <button type="button" id="btn-fail-service">Fail next service call</button>
@@ -615,6 +619,87 @@
         card.hass = environment.hass;
       });
 
+      const demoCard = cards[0] ?? null;
+      const baseConfig = demoCard ? JSON.parse(JSON.stringify(configs[0])) : null;
+      const baseEntityId =
+        typeof (baseConfig?.entity ?? undefined) === "string" ? baseConfig?.entity : undefined;
+
+      function cloneConfig(config) {
+        return JSON.parse(JSON.stringify(config));
+      }
+
+      function applyDemoConfig(config) {
+        if (!demoCard) {
+          return;
+        }
+        demoCard.setConfig(config);
+        demoCard.hass = environment.hass;
+      }
+
+      function clearDemoErrors() {
+        if (!demoCard) {
+          return;
+        }
+        demoCard._errors = [];
+      }
+
+      function bindDemoEntity(entityId) {
+        if (!demoCard) {
+          return;
+        }
+        const controller = demoCard._timerStateController;
+        if (controller) {
+          controller.setEntityId(entityId);
+        }
+      }
+
+      function simulateMissingEntity() {
+        if (!demoCard || !baseConfig) {
+          return;
+        }
+        const config = cloneConfig(baseConfig);
+        delete config.entity;
+        applyDemoConfig(config);
+        clearDemoErrors();
+        bindDemoEntity(undefined);
+      }
+
+      function simulateWrongDomain() {
+        if (!demoCard || !baseConfig) {
+          return;
+        }
+        const entityId = "sensor.demo_timer";
+        const config = { ...cloneConfig(baseConfig), entity: entityId };
+        applyDemoConfig(config);
+        clearDemoErrors();
+        bindDemoEntity(entityId);
+      }
+
+      function simulateUnknownEntity() {
+        if (!demoCard || !baseConfig) {
+          return;
+        }
+        const entityId = "timer.demo_missing";
+        const config = { ...cloneConfig(baseConfig), entity: entityId };
+        applyDemoConfig(config);
+        clearDemoErrors();
+        if (environment.hass?.states) {
+          delete environment.hass.states[entityId];
+        }
+        bindDemoEntity(entityId);
+      }
+
+      function restoreDemoEntity() {
+        if (!demoCard || !baseConfig) {
+          return;
+        }
+        const config = cloneConfig(baseConfig);
+        applyDemoConfig(config);
+        clearDemoErrors();
+        bindDemoEntity(baseEntityId);
+        environment.setIdle();
+      }
+
       function updatePreviewDial(state) {
         if (!previewDial || typeof previewDial.setProgressFraction !== "function") {
           return;
@@ -705,6 +790,10 @@
       document.getElementById("btn-pause").addEventListener("click", () => environment.setPaused(90));
       document.getElementById("btn-finish").addEventListener("click", () => environment.emitFinished());
       document.getElementById("btn-unavailable").addEventListener("click", () => environment.setUnavailable());
+      document.getElementById("btn-missing-entity").addEventListener("click", () => simulateMissingEntity());
+      document.getElementById("btn-wrong-domain").addEventListener("click", () => simulateWrongDomain());
+      document.getElementById("btn-unknown-entity").addEventListener("click", () => simulateUnknownEntity());
+      document.getElementById("btn-reset-entity").addEventListener("click", () => restoreDemoEntity());
       document.getElementById("btn-disconnect").addEventListener("click", () => environment.disconnect());
       document.getElementById("btn-reconnect").addEventListener("click", () => environment.reconnect());
       document.getElementById("btn-fail-service").addEventListener("click", () => environment.failNextServiceCall());

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,15 +3,17 @@
 Something not working as expected? Use this checklist to diagnose the most common Tea Timer Card
 issues.
 
-## Missing or incorrect entity id
+## Entity missing or unavailable
 
-- **Symptom:** Card shows “Entity not found” or displays the wrong timer.
+- **Symptom:** Card shows one of the consolidated entity alerts:
+  - “This card isn’t set up yet. Add a timer entity in the card settings.”
+  - “The configured entity … isn’t a timer (or doesn’t exist). Choose a `timer.*` entity.”
+  - “The timer entity … is unavailable. Check that the helper exists and the `entity_id` is correct.”
 - **Diagnosis:**
-  1. Open **Settings → Devices & services → Helpers** and confirm the timer helper exists.
-  2. Copy the exact entity id (for example `timer.kitchen_tea`).
-  3. Inspect the Lovelace configuration and verify the `entity` value matches.
-- **Fix:** Update the card configuration and reload the dashboard. The card reconnects automatically
-  when the entity id is corrected.
+  1. If the message says the card isn’t set up, edit the Lovelace card and choose a timer helper (`timer.*`).
+  2. If it mentions the entity isn’t a timer, confirm the configured id starts with `timer.` instead of `sensor.` or another domain.
+  3. If it calls out an unavailable timer, open **Settings → Devices & services → Helpers** and ensure the helper is enabled and retains the shown `entity_id`.
+- **Fix:** Update the configuration or helper based on the guidance above. The card hides the dial and presets until the entity reports a healthy state, then resumes normal operation automatically.
 
 ## WebSocket disconnected
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -22,7 +22,9 @@ export interface StringTable {
   dialBlockedTooltip: string;
   disconnectedMessage: string;
   disconnectedReconnectingMessage: string;
-  entityUnavailableBanner: (entityId: string) => string;
+  entityErrorMissing: string;
+  entityErrorInvalid: (entityId?: string) => string;
+  entityErrorUnavailable: (entityId?: string) => string;
   serviceFailureMessage: string;
   durationSpeech: {
     hour: (value: number) => string;
@@ -120,10 +122,15 @@ export const STRINGS: StringTable = {
   disconnectedMessage:
     "Disconnected from Home Assistant. Controls are paused until the link returns.",
   disconnectedReconnectingMessage: "Connection lost—trying to reconnect to Home Assistant…",
-  entityUnavailableBanner: (entityId: string) =>
-    "Timer entity " +
-    entityId +
-    " is unavailable. Open Home Assistant to re-enable it.",
+  entityErrorMissing: "This card isn’t set up yet. Add a timer entity in the card settings.",
+  entityErrorInvalid: (entityId?: string) =>
+    entityId
+      ? `The configured entity ${entityId} isn’t a timer (or doesn’t exist). Choose a timer.* entity.`
+      : "The configured entity isn’t a timer (or doesn’t exist). Choose a timer.* entity.",
+  entityErrorUnavailable: (entityId?: string) =>
+    entityId
+      ? `The timer entity ${entityId} is unavailable. Check that the helper exists and the entity_id is correct.`
+      : "The timer entity is unavailable. Check that the helper exists and the entity_id is correct.",
   serviceFailureMessage:
     "Couldn't complete the timer action. Check your Home Assistant connection and try again.",
   durationSpeech: {

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -308,6 +308,20 @@ export const cardStyles = css`
     color: var(--secondary-text-color, #52606d);
   }
 
+  .entity-error {
+    margin: 16px 0;
+    padding: 12px 14px;
+    border-radius: 12px;
+    background: rgba(191, 26, 47, 0.12);
+    color: #8a1c1c;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  .entity-error-message {
+    margin: 0;
+  }
+
   .errors {
     margin: 0 0 12px;
     padding: 12px;


### PR DESCRIPTION
## Summary
- detect missing, invalid, and unavailable timer entities in `TimerStateController` and surface a single high-priority error state
- render a consolidated alert in `TeaTimerCard`, hiding presets/actions while active and styling the surface for accessibility
- cover the new precedence with unit tests, refresh README/troubleshooting guidance, and extend the demo with entity state toggles

Closes #38

## Acceptance Criteria
- [x] Single surface — missing entity (unit test `entity error surface renders a consolidated message when the entity is missing`)
- [x] Single surface — wrong domain / unknown id (unit tests for wrong domain + recovery)
- [x] Single surface — unavailable (unit test `describes when the timer entity is unavailable`)
- [x] Precedence — disconnected (unit test `suppresses entity errors while disconnected`)
- [x] No duplicate alerts (entity error tests assert a single `[role="alert"]`)
- [x] Secondary hints suppressed (tests verify `.interaction` and preset hints are hidden)
- [x] A11y announcements (single consolidated alert ensures one live region)
- [x] Docs placement (README/troubleshooting updated; runtime card still free of inline doc links per #44)

## Risks & Rollback
- Risk: consolidated logic might hide useful contextual hints if misclassified—rollback by reverting this commit to restore prior per-surface warnings.
- Follow-up: localize the new entity error copy when i18n infrastructure is introduced.


------
https://chatgpt.com/codex/tasks/task_e_68e46bd2ff70833384cc609f5b57d373