### PR TITLE
Prepare v0.3.0 release: UX stabilization docs, release notes, and cross-platform checksums tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to this project will be documented in this file.
 
 - _Nothing yet._
 
+## [0.3.0] - 2026-02-20
+
+### Highlights
+- UX audit follow-up release focused on touch ergonomics, layout stability, and predictable control behavior across idle, running, paused, reconnecting, and error states.
+- Core interaction shell now remains spatially stable across common state transitions, with denser information placement and larger in-face dial readability.
+- Added a finished-state fallback for environments that occasionally miss or skip visible `Done` time before returning to idle.
+
+### Added
+- New `cardBodyTapStart` configuration option (default `true`) to control whether tapping non-control card body regions starts the timer while idle.
+- UX audit evidence pack (`docs/ux-audit.md` plus scenario artifacts) documenting observed flows, tradeoffs, and prioritized improvements.
+
+### Changed
+- Active timer layout now uses a dial-plus-action-rail structure with stable control slots and touch-safe target sizes.
+- Normal timer modes no longer duplicate state labels in multiple places; reclaimed space is applied to a larger dial.
+- Queued preset and custom-duration context now appears in the primary action secondary line instead of separate subtitle/custom rows.
+- State and entity alerts render as overlays to reduce layout reflow and improve consistency during transient errors.
+- Card-body tap behavior is scoped to idle only; running and paused restart paths require explicit action controls.
+
+### Fixed
+- Preserve circular dial geometry at narrow card widths.
+- Suppress duplicate failure messaging when inline banner feedback is active.
+- Restore left-aligned primary action secondary text for improved scanability.
+- Mark finished overlay when running transitions to idle near zero without a finish event.
+
+### Documentation
+- Added touchscreen UX audit scenarios, findings, and acceptance criteria.
+- Updated release documentation, QA matrix, and release checklist for v0.3.0.
+
+### Links
+- Release: [Tea Timer Card v0.3.0](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.3.0)
+
 ## [0.2.0] - 2025-10-14
 
 ### Highlights

--- a/docs/accessibility-and-reduced-motion.md
+++ b/docs/accessibility-and-reduced-motion.md
@@ -7,7 +7,7 @@ Use these notes to verify behavior during accessibility reviews.
 
 1. Title (if present) is skipped to keep focus on interactive elements.
 2. Preset chips appear left-to-right.
-3. The card body (start/restart surface) is last.
+3. The primary action button (`Start`/`Restart`) follows the preset chips.
 
 Keyboard users can cycle through presets with **Tab**/**Shift+Tab** and activate the focused control
 with **Space** or **Enter**. The card exposes ARIA labels that include the preset name and formatted
@@ -42,7 +42,7 @@ duration (for example, “Preset Green Tea – 2 minutes”).
 
 ## Screen reader testing checklist
 
-1. Navigate through presets and the card body using only the keyboard.
+1. Navigate through presets and the primary action using only the keyboard.
 2. Start a brew and confirm you hear a single announcement for the selected preset and duration.
 3. Queue a different preset mid-brew and verify the “Next preset” announcement.
 4. Wait for the brew to finish; listen for the completion message.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -22,7 +22,7 @@ provided for the card to load.
 ### `title`
 
 - **Description:** Text shown at the top of the card.
-- **Default:** No title (the entity id appears in smaller text instead).
+- **Default:** `Tea Timer`.
 - **Example:** `title: Kitchen Tea Timer` helps differentiate multiple cards on the same view.
 
 ### `presets`
@@ -76,6 +76,15 @@ provided for the card to load.
 - **Default:** `false` (restarts immediately).
 - **Example:** `confirmRestart: true` forces a confirmation dialog before canceling a brew in
   progress.
+
+### `cardBodyTapStart`
+
+- **Description:** Enables one-tap start from non-control card body regions while the timer is idle.
+  This setting has no effect while running or paused, where restart always requires explicit action
+  controls.
+- **Default:** `true`.
+- **Example:** `cardBodyTapStart: false` disables idle card-body start so users must tap the primary
+  `Start` action.
 
 ### `finishedAutoIdleMs`
 
@@ -156,6 +165,7 @@ defaultPreset: Assam
 minDurationSeconds: 30
 maxDurationSeconds: 1200
 stepSeconds: 5
+cardBodyTapStart: true
 confirmRestart: false
 finishedAutoIdleMs: 5000
 ```

--- a/docs/presets-and-durations.md
+++ b/docs/presets-and-durations.md
@@ -44,7 +44,7 @@ presets:
 Selecting a preset while the timer runs does not interrupt the current brew. Instead:
 
 1. The card announces the next preset (for example, “Next: Herbal 5:00”).
-2. The queued preset appears in the subtitle to signal the pending change.
+2. The queued preset appears as context in the primary action secondary line to signal the pending change.
 3. When you restart the timer—either manually or when it finishes—the queued preset becomes active.
 
 This behavior keeps the running brew predictable while still letting you line up the next tea.

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -1,50 +1,49 @@
-# QA matrix — Tea Timer Card v0.2.0
+# QA matrix — Tea Timer Card v0.3.0
 
 ## Summary
 
-- Release tag: `v0.2.0`
-- Minimum Home Assistant version: **2024.7.0** (validated on `core-2024.7.3`).
-- Known limitations: Lovelace resource cache must be refreshed after updating assets; pause/resume helper fallback still
-  requires the optional `input_text` entity on Home Assistant versions without native `timer.pause`.
+- Release tag: `v0.3.0`
+- Minimum Home Assistant version: **2024.7.0**
+- Focus areas in this cycle: touch UX stability, layout consistency across states, narrow-width dial integrity, and finished-state resilience.
+- Evidence set:
+  - Structured observations: [`docs/qa/artifacts/2026-02-07/ux-audit/ux-observations.json`](qa/artifacts/2026-02-07/ux-audit/ux-observations.json)
+  - Screenshot sample: [`docs/qa/artifacts/2026-02-07/ux-audit/01-idle-baseline.png`](qa/artifacts/2026-02-07/ux-audit/01-idle-baseline.png)
+  - UX findings and prioritization: [`docs/ux-audit.md`](ux-audit.md)
 
 ## Home Assistant coverage
 
 | Home Assistant version | Installation method | Result | Notes |
 | --- | --- | --- | --- |
-| core-2024.7.3 (Supervisor) | HACS custom repository install | ✅ | Stable loader `tea-timer-card.js` references fingerprinted bundle after browser refresh. |
-| core-2024.7.3 (Supervisor) | Manual copy of release assets | ✅ | `checksums.txt` verified locally; Lovelace resource `/local/tea-timer-card.js`. |
+| core-2024.7.x | HACS custom repository install | ✅ | Stable loader `tea-timer-card.js` references fingerprinted bundle after browser refresh. |
+| core-2024.7.x | Manual copy of release assets | ✅ | Release workflow packages loader, fingerprinted bundle, source map, and checksums. |
 
 ## Browser & device coverage
 
-| Browser | Version | OS / Device | Layout | Result | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Chrome | 127 | Windows 11 (desktop) | Light & dark | ✅ | Dial, presets, pause/resume, and extend flows validated. |
-| Microsoft Edge | 127 | Windows 11 (desktop) | Light | ✅ | Keyboard navigation, screen reader announcements, and extend button tested. |
-| Firefox | 128 | macOS Sonoma (desktop) | Light & dark | ✅ | Reduced-motion preference disables animations and preserves pause overlay. |
-| Safari | iOS 17.5 (iPhone 14) | Mobile | Dark | ✅ | Multi-device sync confirmed; touch hold for pause/resume stable. |
-| Chrome | Android 14 (Pixel 7) | Mobile | Light | ✅ | Touch interactions, queued presets, and extend button verified. |
+| Browser | OS / Device | Layout | Result | Notes |
+| --- | --- | --- | --- | --- |
+| Chrome | Windows 11 desktop | Light | ✅ | Baseline interaction shell, queued presets, and restart semantics validated. |
+| Microsoft Edge | Windows 11 desktop | Light | ✅ | Confirmed finished overlay timing and idle fallback behavior. |
+| Chrome | Android 14 phone | Mobile | ✅ | Touch targets and dial-plus-rail flow validated. |
+| Fully Kiosk Browser | Older Android tablet | Kiosk/mobile | ✅ | Verified fallback finished overlay behavior when native finished transition is skipped. |
 
 ## Network conditions
 
 | Network profile | Result | Notes |
 | --- | --- | --- |
-| Normal LAN (<20 ms) | ✅ | Baseline for Home Assistant dashboard usage. |
-| High latency (200 ms, 2% packet loss) | ✅ | Countdown remains monotonic; pause overlay recovers after jitter. |
-| Intermittent (lossy Wi-Fi, brief disconnects) | ✅ | “Disconnected” banner surfaces and clears once WebSocket recovers. |
+| Normal LAN (<20 ms) | ✅ | Baseline dashboard behavior. |
+| Intermittent connectivity | ✅ | Reconnecting overlay and control disablement behave consistently. |
 
 ## Feature scenarios
 
 | Scenario | Result | Notes |
 | --- | --- | --- |
-| Idle → start via tap | ✅ | Service call uses selected preset duration. |
-| Running → restart | ✅ | Restart overlay displayed, countdown resets. |
-| Pause → resume | ✅ | Native `timer.pause` path verified; helper fallback exercised on 2024.7.0. |
-| Extend while running | ✅ | `timer.change` increments remaining time without resetting countdown. |
-| Finish overlay | ✅ | Five-second “Done” banner auto-dismissed. |
-| Preset queue while running | ✅ | “Next:” subtitle and queued restart honored. |
-| Entity unavailable handling | ✅ | Error banner & retry messaging displayed. |
-| Reduced-motion | ✅ | Dial animation disabled when `prefers-reduced-motion: reduce`. |
-| Accessibility announcements | ✅ | Live region updates throttled per spec. |
+| Idle -> start via card body tap | ✅ | Enabled only in idle mode; guarded by `cardBodyTapStart`. |
+| Running/paused accidental card-body restart prevention | ✅ | Restart requires explicit action control. |
+| Running -> queued preset feedback | ✅ | Context rendered in primary action secondary line (no dedicated subtitle row). |
+| Overlay feedback surfaces | ✅ | Reconnecting/service/entity alerts render without shifting core shell layout. |
+| Narrow-width dial rendering | ✅ | Dial maintains circular geometry under constrained widths. |
+| Finished -> idle fallback without finish event | ✅ | Near-zero running->idle transitions still show finished state before auto-idle timeout. |
+| Pause/resume and extend controls | ✅ | Touch-safe targets and rail grouping verified. |
 
 ## Automated checks
 
@@ -52,10 +51,5 @@
 - `npm run typecheck`
 - `npm test`
 - `npm run build`
-
-## Manual QA notes
-
-- Monitored memory usage in dev playground during 45-minute run mixing extend/pause/resume; no growth observed beyond normal
-  GC churn.
-- Verified that Lovelace resources load the hashed bundle after cache clear, ensuring cache busting between releases.
-- Confirmed pause/resume helper fallback by temporarily removing native `timer.pause` support.
+- `npm run docs:check`
+- `npm run release:verify`

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
-# Release checklist — Tea Timer Card v0.2.0
+# Release checklist — Tea Timer Card v0.3.0
 
-This checklist captures the release gates from [Issue #72](https://github.com/sharwell/ha-tea-timer/issues/72) and records how they were satisfied for the pause/resume + extend quality release.
+This checklist records release gates for the UX stabilization release prepared from the `ux-audit` branch.
 
 ## Quality gates
 
@@ -8,39 +8,40 @@ This checklist captures the release gates from [Issue #72](https://github.com/sh
 - [x] `npm run typecheck`
 - [x] `npm test`
 - [x] `npm run build`
-- [x] Accessibility, reduced-motion, and performance spot checks completed in the playground (`npm run dev`).
+- [x] `npm run docs:check`
 
 ## Packaging & distribution
 
 - [x] Vite emits a fingerprinted bundle (`tea-timer-card.<hash>.js`) with source maps.
 - [x] Stable loader `tea-timer-card.js` re-exports the fingerprinted build for Lovelace resources and HACS.
-- [x] SHA-256 checksums captured via `npm run release:checksums`.
-- [x] Release workflow (`.github/workflows/release.yml`) attaches artifacts and notes from `docs/releases/v0.2.0.md` when a `v*` tag is pushed.
+- [x] Release verification script (`npm run release:verify`) passes against generated build artifacts.
+- [x] SHA-256 checksums can be produced via `npm run release:checksums`.
+- [x] Release workflow (`.github/workflows/release.yml`) publishes artifacts and uses `docs/releases/v0.3.0.md` as release notes when tag `v0.3.0` is pushed.
 
 ## Documentation & links
 
-- [x] `CHANGELOG.md` documents highlights and links to the v0.2.0 release.
-- [x] Release notes link to [Getting Started](getting-started.md) and [Automate on finish](automations/finished.md).
-- [x] README installation section references the v0.2.0 assets and explains the stable loader strategy.
-- [x] QA evidence recorded in [docs/qa-matrix.md](qa-matrix.md).
+- [x] `CHANGELOG.md` includes v0.3.0 highlights and release link.
+- [x] `README.md` points installation guidance to v0.3.0 assets and current behavior semantics.
+- [x] Release notes are documented in [`docs/releases/v0.3.0.md`](releases/v0.3.0.md).
+- [x] QA evidence is captured in [`docs/qa-matrix.md`](qa-matrix.md) and [`docs/ux-audit.md`](ux-audit.md).
 
 ## Compatibility & QA results
 
-- Minimum Home Assistant version: **2024.7.0** (`core-2024.7.3`).
-- Browsers/devices covered: Chrome 127 (Windows 11), Edge 127 (Windows 11), Firefox 128 (macOS Sonoma), Safari on iOS 17.5, Chrome on Android 14.
-- Manual QA summary: dial interaction, preset queueing, extend button, pause/resume (native + helper fallback), and reduced-motion behavior validated across desktop & mobile layouts.
+- Minimum Home Assistant version: **2024.7.0**.
+- Browser/device coverage retained from v0.2.0 matrix plus UX-audit validation artifacts.
+- Additional manual spot-check: older Android tablet in Fully Kiosk Browser confirmed finished-state fallback behavior.
 
 ## Known limitations carried into release
 
-- Pause/resume helper fallback still requires an `input_text` entity when Home Assistant lacks native `timer.pause`.
-- Restart confirmation optional and off by default; no mid-run cancel.
-- Manual Lovelace resource reload required after updating assets.
+- Pause/resume helper fallback still requires `input_text.<entity>_paused_remaining` on Home Assistant versions without native `timer.pause`.
+- Manual Lovelace resource reload may still be required after updating assets.
+- Dashboard-level viewport behavior can vary in kiosk shells that override browser scaling defaults.
 
 ## Triage
 
-- [x] No open P0/P1 issues at release time. Known limitations captured above.
+- [x] No open P0 defects blocking v0.3.0 release preparation in this branch.
 
 ## Sign-off
 
 - Release owner: _Tea Timer maintainers_
-- Date: 2025-10-14
+- Date: 2026-02-20

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,50 @@
+# Tea Timer Card v0.3.0
+
+> Release date: 2026-02-20 • Minimum Home Assistant: 2024.7.0
+
+## Highlights
+
+- Touch-first UX refresh driven by a structured 23-scenario audit. The card now keeps a more stable control shell across common transitions and improves action predictability.
+- Improved information density and readability: a larger dial, fewer duplicated status labels, and tighter action grouping while preserving touch-safe targets.
+- Better resilience in real-world kiosk environments: added finished-state fallback logic when a `timer.finished` event is delayed or missed.
+
+## Install / Update
+
+1. Review the [release checklist](../release-checklist.md) to confirm quality gates and release sign-off for this build.
+2. Install via HACS (custom repository) or download the assets attached to the
+   [Tea Timer Card v0.3.0 release](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.3.0):
+   `tea-timer-card.js`, `tea-timer-card.<hash>.js`, optional `tea-timer-card.<hash>.js.map`, and `checksums.txt`.
+3. Verify SHA-256 checksums before copying files into `<config>/www/` for manual installs.
+4. Ensure your Lovelace resource points at `/local/tea-timer-card.js`; the stable loader imports the
+   fingerprinted bundle packaged with this release.
+
+## Notable behavior changes
+
+- Card-body tap start is now idle-only. Restart while running/paused requires explicit action controls.
+- Queued preset and custom-duration context moved into the primary action secondary line.
+- Transient state and entity errors render as overlays to reduce layout reflow.
+- Running/paused controls use a consistent dial-plus-rail arrangement with larger, touch-safe targets.
+
+## Compatibility
+
+- Minimum Home Assistant core: **2024.7.0**.
+- Existing v0.2.x YAML remains compatible; no breaking configuration changes.
+- New optional config: `cardBodyTapStart` (default `true`) for controlling idle card-body tap start behavior.
+
+## Known limitations
+
+- Home Assistant cores without native `timer.pause` still require the optional `input_text.<entity>_paused_remaining`
+  helper to expose pause/resume controls.
+- Browser resource cache refresh may still be required after updating bundled assets.
+
+## Troubleshooting & docs
+
+- Review [Getting Started](../getting-started.md) for installation and first-run checks.
+- See [State & actions](../state-and-actions.md) for current interaction semantics.
+- Refer to [Touch UX audit](../ux-audit.md) for scenario evidence and rationale behind this release’s layout and interaction changes.
+- Use [Automate on `timer.finished`](../automations/finished.md) for automation patterns and edge-case notes.
+
+## Feedback
+
+- File bugs or regression reports at the [issue tracker](https://github.com/sharwell/ha-tea-timer/issues).
+- For release-specific feedback, include screenshots, viewport width, platform/browser, and whether Home Assistant is running in kiosk mode.

--- a/docs/state-and-actions.md
+++ b/docs/state-and-actions.md
@@ -21,20 +21,22 @@ stateDiagram-v2
 
 ## Idle
 
-- **What you see:** Dial is interactive, presets respond instantly, subtitle shows the selected
-  preset or custom duration.
+- **What you see:** Dial is interactive, presets respond instantly, and the primary action shows the
+  selected duration.
 - **Actions available:**
   - Drag the dial or use arrow keys/PageUp/PageDown to change the duration (rounded to `stepSeconds`).
-  - Tap/click/press **Space** or **Enter** anywhere on the card body to start the timer.
+  - Tap/click the primary **Start** action, or press **Space**/**Enter** while the button is focused.
+  - Optionally tap the card body to start when `cardBodyTapStart: true` (default).
   - Pick a preset to update the dial.
 - **Announcements:** Screen readers hear the selected preset and duration when it changes.
 
 ## Running
 
 - **What you see:** Dial locks, the handle hides, a progress arc fills clockwise, remaining time
-  updates once per second (throttled for screen readers), and queued presets appear as a subtitle.
+  updates once per second (throttled for screen readers), and queued presets appear as context in
+  the primary action secondary line.
 - **Actions available:**
-  - Tap/click the card to restart with the queued duration.
+  - Tap/click **Restart** to restart with the current or queued duration.
   - Change presets—the card queues the new selection for the next restart without interrupting the
     current brew.
   - Tap the **Pause** control to halt the brew without resetting the remaining time. The button
@@ -51,8 +53,8 @@ stateDiagram-v2
 ## Paused
 
 - **What you see:** The dial remains locked with the handle hidden, the progress arc freezes in
-  place, and a “Paused” badge appears above the card body. Resume and Restart controls replace the
-  Pause button.
+  place, and the in-dial secondary text shows **Paused**. Resume and Restart controls replace the
+  running-state action set.
 - **Actions available:**
   - Tap **Resume** to continue from the stored remaining time (Home Assistant may emit
     `timer.restarted`; rely on `timer.finished` for automations).
@@ -68,8 +70,8 @@ stateDiagram-v2
 - **What you see:** The card displays **Done** with an optional preset label. A translucent overlay
   lasts `finishedAutoIdleMs` milliseconds (default 5000) before returning to Idle.
 - **Actions available:**
-  - Tap/click/press **Space** or **Enter** to restart immediately using the same duration or a queued
-    preset.
+  - Tap/click **Start** (or press **Space**/**Enter** while focused) to start immediately using the
+    same duration or a queued preset.
   - Let the overlay expire; the card automatically returns to Idle and restores dial interaction.
 - **Announcements:** “Brew finished – Done” with the preset label when available.
 
@@ -89,7 +91,7 @@ stateDiagram-v2
 
 ## Keyboard & pointer shortcuts
 
-- **Start or restart:** **Space** or **Enter** when the card is focused.
+- **Start or restart:** **Space** or **Enter** on the focused primary action button.
 - **Adjust duration:**
   - **Arrow keys:** ±`stepSeconds`.
   - **PageUp/PageDown:** ±30 seconds.

--- a/docs/visual-editor.md
+++ b/docs/visual-editor.md
@@ -4,7 +4,7 @@ Home Assistant's Lovelace editor now includes the Tea Timer card in the **Add ca
 
 ## Requirements
 
-- Tea Timer Card v0.2.0 or later (Unreleased)
+- Tea Timer Card v0.2.0 or later
 - Home Assistant 2023.12 or newer with Lovelace dashboards
 - A `timer` helper for each brew you want to control
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-tea-timer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-tea-timer",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tea-timer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Tea Timer custom card for Home Assistant",
   "type": "module",
   "scripts": {
@@ -12,10 +12,10 @@
     "test": "vitest run",
     "lint:markdown": "markdownlint \"docs/**/*.md\" README.md",
     "lint:spell": "cspell \"docs/**/*.md\" \"README.md\"",
-    "lint:links": "linkinator \"docs/**/*.md\" README.md --recurse --silent --skip \"http://localhost:5173/\" --skip \"https://hacs.xyz/*\" --skip \"https://www.home-assistant.io/*\" --skip \"https://github.com/sharwell/ha-tea-timer/releases/tag/v0.2.0\"",
+    "lint:links": "linkinator \"docs/**/*.md\" README.md --recurse --silent --skip \"http://localhost:5173/\" --skip \"https://hacs.xyz/*\" --skip \"https://www.home-assistant.io/*\" --skip \"https://github.com/sharwell/ha-tea-timer/releases/tag/v0.3.0\"",
     "docs:check": "npm run lint:markdown && npm run lint:spell && npm run lint:links",
     "release:verify": "node scripts/release/assert-artifacts.mjs",
-    "release:checksums": "scripts/release/checksums.sh"
+    "release:checksums": "node scripts/release/checksums.mjs"
   },
   "keywords": [
     "home-assistant",

--- a/scripts/release/checksums.mjs
+++ b/scripts/release/checksums.mjs
@@ -1,0 +1,43 @@
+import { createHash } from "crypto";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const DIST_DIR = path.join(ROOT_DIR, "dist");
+const OUTPUT_FILE = path.join(ROOT_DIR, "checksums.txt");
+
+async function main() {
+  let entries;
+  try {
+    entries = await fs.readdir(DIST_DIR, { withFileTypes: true });
+  } catch (error) {
+    throw new Error(
+      `dist directory not found at ${DIST_DIR}. Run 'npm run build' before generating checksums.`,
+    );
+  }
+
+  const files = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+
+  if (files.length === 0) {
+    throw new Error("No files found in dist to checksum.");
+  }
+
+  const lines = [];
+  for (const file of files) {
+    const content = await fs.readFile(path.join(DIST_DIR, file));
+    const digest = createHash("sha256").update(content).digest("hex");
+    lines.push(`${digest}  ${file}`);
+  }
+
+  await fs.writeFile(OUTPUT_FILE, `${lines.join("\n")}\n`, "utf8");
+  console.error(`Wrote SHA-256 checksums to ${OUTPUT_FILE}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

This PR prepares and documents the **v0.3.0** release of Tea Timer Card.

The release centers on the UX stabilization work from the `ux-audit` effort: more predictable touch interactions, improved layout consistency, denser/clearer control presentation, and better resilience around finished-state transitions.

## What’s included

- Version bump to `0.3.0` in package metadata.
- New release notes document: `docs/releases/v0.3.0.md`.
- Changelog entry for `0.3.0` in `CHANGELOG.md`.
- README and docs updates to match current behavior and release links.
- QA/release governance refresh:
  - `docs/qa-matrix.md`
  - `docs/release-checklist.md`
- Configuration docs updated for `cardBodyTapStart`.
- Cross-platform release improvement:
  - replaced Bash-only checksum generation with `scripts/release/checksums.mjs`
  - updated `release:checksums` script accordingly.

## Behavior notes for reviewers

- No breaking config changes.
- `cardBodyTapStart` is available (default `true`) to control idle card-body tap-to-start.
- Running/paused restart remains explicit via action controls.
- Queued/custom context is shown in primary action secondary text rather than a reserved subtitle row.

## Validation

The following all pass on this branch:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run docs:check`
- `npm run release:verify`
- `npm run release:checksums`
