### PR TITLE
Improve dial legibility and finished-state reliability on older WebViews

### DIFF
--- a/src/dial/TeaTimerDial.test.ts
+++ b/src/dial/TeaTimerDial.test.ts
@@ -113,6 +113,22 @@ describe("TeaTimerDial", () => {
     dial.remove();
   });
 
+  it("hides the handle when finished", async () => {
+    const dial = document.createElement("tea-timer-dial");
+    dial.bounds = { min: 15, max: 360, step: 5 };
+    dial.value = 0;
+    dial.status = "finished";
+    dial.interactive = false;
+
+    const { root } = await renderDial(dial);
+
+    expect(root.classList.contains("is-finished")).toBe(true);
+    expect(root.tabIndex).toBe(-1);
+    expect(root.getAttribute("aria-disabled")).toBe("true");
+
+    dial.remove();
+  });
+
   it("shows the handle and allows focus while idle", async () => {
     const dial = document.createElement("tea-timer-dial");
     dial.bounds = { min: 15, max: 360, step: 5 };

--- a/src/dial/TeaTimerDial.ts
+++ b/src/dial/TeaTimerDial.ts
@@ -133,7 +133,8 @@ export class TeaTimerDial extends LitElement {
     }
 
     .dial-root.is-running .dial-handle,
-    .dial-root.is-paused .dial-handle {
+    .dial-root.is-paused .dial-handle,
+    .dial-root.is-finished .dial-handle {
       opacity: 0;
       visibility: hidden;
     }
@@ -269,6 +270,8 @@ export class TeaTimerDial extends LitElement {
       rootClass += " is-running";
     } else if (status === "paused") {
       rootClass += " is-paused";
+    } else if (status === "finished") {
+      rootClass += " is-finished";
     }
     const tabIndex = this.interactive ? 0 : -1;
     const ariaDisabled = this.interactive ? "false" : "true";

--- a/src/dial/TeaTimerDial.ts
+++ b/src/dial/TeaTimerDial.ts
@@ -25,6 +25,7 @@ export class TeaTimerDial extends LitElement {
 
     .dial-root {
       position: relative;
+      container-type: inline-size;
       box-sizing: border-box;
       width: min(100%, var(--tea-timer-dial-size, 228px));
       max-width: var(--tea-timer-dial-size, 228px);
@@ -162,6 +163,10 @@ export class TeaTimerDial extends LitElement {
 
     ::slotted([slot="primary"]) {
       font-size: var(--tea-timer-dial-primary-font-size, 2.6rem);
+      font-size: min(
+        var(--tea-timer-dial-primary-font-size, 2.6rem),
+        var(--tea-timer-dial-primary-fluid-size, 22cqi)
+      );
       font-weight: 700;
       font-variant-numeric: tabular-nums;
       letter-spacing: 0.01em;
@@ -170,6 +175,10 @@ export class TeaTimerDial extends LitElement {
 
     ::slotted([slot="secondary"]) {
       font-size: var(--tea-timer-dial-secondary-font-size, 1rem);
+      font-size: min(
+        var(--tea-timer-dial-secondary-font-size, 1rem),
+        var(--tea-timer-dial-secondary-fluid-size, 7.4cqi)
+      );
       color: var(--secondary-text-color, #52606d);
       line-height: 1.15;
     }

--- a/src/dial/TeaTimerDial.ts
+++ b/src/dial/TeaTimerDial.ts
@@ -161,15 +161,17 @@ export class TeaTimerDial extends LitElement {
     }
 
     ::slotted([slot="primary"]) {
-      font-size: 2rem;
-      font-weight: 600;
-      letter-spacing: 0.02em;
+      font-size: var(--tea-timer-dial-primary-font-size, 2.6rem);
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+      letter-spacing: 0.01em;
       line-height: 1;
     }
 
     ::slotted([slot="secondary"]) {
-      font-size: 1rem;
+      font-size: var(--tea-timer-dial-secondary-font-size, 1rem);
       color: var(--secondary-text-color, #52606d);
+      line-height: 1.15;
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/src/state/TimerStateController.test.ts
+++ b/src/state/TimerStateController.test.ts
@@ -143,6 +143,7 @@ describe("TimerStateController finished fallback", () => {
       previousEntityState?: MachineTimerViewState;
       serverRemainingSecAtT0?: number;
       clientMonotonicT0?: number;
+      clientWallT0?: number;
       applyEntityState(state: MachineTimerViewState): void;
       currentState: { status: string };
     };
@@ -156,6 +157,7 @@ describe("TimerStateController finished fallback", () => {
     };
     internals.serverRemainingSecAtT0 = 0.4;
     internals.clientMonotonicT0 = monotonicNow - 350;
+    internals.clientWallT0 = wallNow - 350;
 
     wallNow += 350;
     monotonicNow += 350;
@@ -183,6 +185,7 @@ describe("TimerStateController finished fallback", () => {
       previousEntityState?: MachineTimerViewState;
       serverRemainingSecAtT0?: number;
       clientMonotonicT0?: number;
+      clientWallT0?: number;
       applyEntityState(state: MachineTimerViewState): void;
       currentState: { status: string };
     };
@@ -196,6 +199,7 @@ describe("TimerStateController finished fallback", () => {
     };
     internals.serverRemainingSecAtT0 = 15;
     internals.clientMonotonicT0 = monotonicNow - 2_000;
+    internals.clientWallT0 = wallNow - 2_000;
 
     wallNow += 2_000;
     monotonicNow += 2_000;
@@ -208,6 +212,48 @@ describe("TimerStateController finished fallback", () => {
     });
 
     expect(internals.currentState.status).toBe("idle");
+  });
+
+  it("marks finished when monotonic time lags but wall time indicates expiry", () => {
+    let wallNow = 2_000_000;
+    let monotonicNow = 10_000;
+    const controller = new TimerStateController(new TestHost(), {
+      now: () => wallNow,
+      monotonicNow: () => monotonicNow,
+    });
+
+    const internals = controller as unknown as {
+      connectionStatus: "connected" | "disconnected" | "reconnecting";
+      previousEntityState?: MachineTimerViewState;
+      serverRemainingSecAtT0?: number;
+      clientMonotonicT0?: number;
+      clientWallT0?: number;
+      applyEntityState(state: MachineTimerViewState): void;
+      currentState: { status: string };
+    };
+
+    internals.connectionStatus = "connected";
+    internals.previousEntityState = {
+      status: "running",
+      durationSeconds: 30,
+      remainingSeconds: 3,
+      lastChangedTs: wallNow - 3_000,
+    };
+    internals.serverRemainingSecAtT0 = 3;
+    internals.clientMonotonicT0 = monotonicNow - 200;
+    internals.clientWallT0 = wallNow - 2_950;
+
+    wallNow += 2_950;
+    monotonicNow += 200;
+
+    internals.applyEntityState({
+      status: "idle",
+      durationSeconds: 30,
+      remainingSeconds: 30,
+      lastChangedTs: wallNow,
+    });
+
+    expect(internals.currentState.status).toBe("finished");
   });
 });
 

--- a/src/state/TimerStateController.test.ts
+++ b/src/state/TimerStateController.test.ts
@@ -255,5 +255,49 @@ describe("TimerStateController finished fallback", () => {
 
     expect(internals.currentState.status).toBe("finished");
   });
+
+  it("marks finished when running->idle arrives with stale baseline but last_changed indicates near-zero", () => {
+    let wallNow = 3_000_000;
+    let monotonicNow = 15_000;
+    const controller = new TimerStateController(new TestHost(), {
+      now: () => wallNow,
+      monotonicNow: () => monotonicNow,
+    });
+
+    const internals = controller as unknown as {
+      connectionStatus: "connected" | "disconnected" | "reconnecting";
+      previousEntityState?: MachineTimerViewState;
+      serverRemainingSecAtT0?: number;
+      clientMonotonicT0?: number;
+      clientWallT0?: number;
+      applyEntityState(state: MachineTimerViewState): void;
+      currentState: { status: string };
+    };
+
+    internals.connectionStatus = "connected";
+    internals.previousEntityState = {
+      status: "running",
+      durationSeconds: 240,
+      remainingSeconds: 40,
+      lastChangedTs: wallNow - 239_000,
+    };
+
+    // Simulate stale/invalid running baselines from a throttled environment.
+    internals.serverRemainingSecAtT0 = undefined;
+    internals.clientMonotonicT0 = undefined;
+    internals.clientWallT0 = undefined;
+
+    wallNow += 1_200;
+    monotonicNow += 250;
+
+    internals.applyEntityState({
+      status: "idle",
+      durationSeconds: 240,
+      remainingSeconds: 240,
+      lastChangedTs: wallNow,
+    });
+
+    expect(internals.currentState.status).toBe("finished");
+  });
 });
 

--- a/src/state/TimerStateController.ts
+++ b/src/state/TimerStateController.ts
@@ -57,7 +57,7 @@ export interface TimerStateControllerOptions {
   clockSkewEstimatorEnabled?: boolean;
 }
 
-const FINISH_FALLBACK_MAX_REMAINING_SECONDS = 1;
+const FINISH_FALLBACK_MAX_REMAINING_SECONDS = 2;
 
 interface ConnectionMonitor {
   connection: HassConnection;
@@ -541,6 +541,12 @@ export class TimerStateController implements ReactiveController {
     if (this.serverRemainingSecAtT0 !== undefined && this.clientWallT0 !== undefined) {
       const elapsedSeconds = Math.max(0, this.getCurrentTime() - this.clientWallT0) / 1000;
       remainingCandidates.push(Math.max(0, this.serverRemainingSecAtT0 - elapsedSeconds));
+    }
+
+    if (previous.durationSeconds !== undefined && previous.lastChangedTs !== undefined) {
+      const serverNow = this.getServerNow(this.getCurrentTime()) ?? this.getCurrentTime();
+      const elapsedSeconds = Math.max(0, serverNow - previous.lastChangedTs) / 1000;
+      remainingCandidates.push(Math.max(0, previous.durationSeconds - elapsedSeconds));
     }
 
     if (remainingCandidates.length === 0 && previous.remainingSeconds !== undefined) {

--- a/src/state/TimerStateController.ts
+++ b/src/state/TimerStateController.ts
@@ -117,6 +117,8 @@ export class TimerStateController implements ReactiveController {
 
   private clientMonotonicT0?: number;
 
+  private clientWallT0?: number;
+
   private baselineEndMs?: number;
 
   private previousEntityState?: TimerEntityState;
@@ -530,15 +532,23 @@ export class TimerStateController implements ReactiveController {
       return false;
     }
 
-    let projectedRemaining: number | undefined;
+    const remainingCandidates: number[] = [];
     if (this.serverRemainingSecAtT0 !== undefined && this.clientMonotonicT0 !== undefined) {
       const elapsedSeconds = Math.max(0, this.monotonicNow() - this.clientMonotonicT0) / 1000;
-      projectedRemaining = Math.max(0, this.serverRemainingSecAtT0 - elapsedSeconds);
+      remainingCandidates.push(Math.max(0, this.serverRemainingSecAtT0 - elapsedSeconds));
     }
 
-    if (projectedRemaining === undefined && previous.remainingSeconds !== undefined) {
-      projectedRemaining = Math.max(0, previous.remainingSeconds);
+    if (this.serverRemainingSecAtT0 !== undefined && this.clientWallT0 !== undefined) {
+      const elapsedSeconds = Math.max(0, this.getCurrentTime() - this.clientWallT0) / 1000;
+      remainingCandidates.push(Math.max(0, this.serverRemainingSecAtT0 - elapsedSeconds));
     }
+
+    if (remainingCandidates.length === 0 && previous.remainingSeconds !== undefined) {
+      remainingCandidates.push(Math.max(0, previous.remainingSeconds));
+    }
+
+    const projectedRemaining =
+      remainingCandidates.length > 0 ? Math.min(...remainingCandidates) : undefined;
 
     if (projectedRemaining === undefined) {
       return false;
@@ -589,6 +599,7 @@ export class TimerStateController implements ReactiveController {
 
     let serverRemainingSecAtT0 = this.serverRemainingSecAtT0;
     let clientMonotonicT0 = this.clientMonotonicT0;
+    let clientWallT0 = this.clientWallT0;
     let baselineEndMs = this.baselineEndMs;
 
     if (connectionStatus !== "connected") {
@@ -599,6 +610,7 @@ export class TimerStateController implements ReactiveController {
       if (seed) {
         serverRemainingSecAtT0 = seed.remainingSeconds;
         clientMonotonicT0 = seed.monotonicT0;
+        clientWallT0 = seed.wallT0;
         baselineEndMs = seed.baselineEndMs;
       }
     } else if (entityState.status === "paused") {
@@ -608,15 +620,18 @@ export class TimerStateController implements ReactiveController {
         serverRemainingSecAtT0 = undefined;
       }
       clientMonotonicT0 = undefined;
+      clientWallT0 = undefined;
       baselineEndMs = undefined;
     } else {
       serverRemainingSecAtT0 = undefined;
       clientMonotonicT0 = undefined;
+      clientWallT0 = undefined;
       baselineEndMs = undefined;
     }
 
     this.serverRemainingSecAtT0 = serverRemainingSecAtT0;
     this.clientMonotonicT0 = clientMonotonicT0;
+    this.clientWallT0 = clientWallT0;
     this.baselineEndMs = baselineEndMs;
 
     this.currentState = {
@@ -641,6 +656,7 @@ export class TimerStateController implements ReactiveController {
     | {
         remainingSeconds: number;
         monotonicT0: number;
+        wallT0: number;
         baselineEndMs: number;
       }
     | undefined {
@@ -690,6 +706,7 @@ export class TimerStateController implements ReactiveController {
     return {
       remainingSeconds,
       monotonicT0,
+      wallT0: wallNow,
       baselineEndMs: monotonicT0 + remainingSeconds * 1000,
     };
   }

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -6,7 +6,9 @@ export const cardStyles = css`
     color: var(--primary-text-color, #1f2933);
     --tea-timer-dial-size: 228px;
     --tea-timer-dial-primary-font-size: 3.1rem;
+    --tea-timer-dial-primary-fluid-size: 26.67cqi;
     --tea-timer-dial-secondary-font-size: 1.05rem;
+    --tea-timer-dial-secondary-fluid-size: 9.03cqi;
     --mdc-theme-primary: var(--primary-color, #1f2933);
     --mdc-theme-on-primary: var(
       --text-on-primary-color,
@@ -589,7 +591,9 @@ export const cardStyles = css`
     :host {
       --tea-timer-dial-size: 220px;
       --tea-timer-dial-primary-font-size: 2.9rem;
+      --tea-timer-dial-primary-fluid-size: 26.07cqi;
       --tea-timer-dial-secondary-font-size: 1.02rem;
+      --tea-timer-dial-secondary-fluid-size: 9.17cqi;
     }
   }
 
@@ -597,7 +601,9 @@ export const cardStyles = css`
     :host {
       --tea-timer-dial-size: 236px;
       --tea-timer-dial-primary-font-size: 3.3rem;
+      --tea-timer-dial-primary-fluid-size: 27.22cqi;
       --tea-timer-dial-secondary-font-size: 1.1rem;
+      --tea-timer-dial-secondary-fluid-size: 9.07cqi;
     }
   }
 `;

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -5,6 +5,8 @@ export const cardStyles = css`
     color-scheme: light dark;
     color: var(--primary-text-color, #1f2933);
     --tea-timer-dial-size: 228px;
+    --tea-timer-dial-primary-font-size: 2.6rem;
+    --tea-timer-dial-secondary-font-size: 1.02rem;
     --mdc-theme-primary: var(--primary-color, #1f2933);
     --mdc-theme-on-primary: var(
       --text-on-primary-color,
@@ -586,12 +588,16 @@ export const cardStyles = css`
   @media (max-width: 420px) {
     :host {
       --tea-timer-dial-size: 220px;
+      --tea-timer-dial-primary-font-size: 2.45rem;
+      --tea-timer-dial-secondary-font-size: 1rem;
     }
   }
 
   @media (min-width: 520px) {
     :host {
       --tea-timer-dial-size: 236px;
+      --tea-timer-dial-primary-font-size: 2.7rem;
+      --tea-timer-dial-secondary-font-size: 1.06rem;
     }
   }
 `;

--- a/src/styles/card.ts
+++ b/src/styles/card.ts
@@ -5,8 +5,8 @@ export const cardStyles = css`
     color-scheme: light dark;
     color: var(--primary-text-color, #1f2933);
     --tea-timer-dial-size: 228px;
-    --tea-timer-dial-primary-font-size: 2.6rem;
-    --tea-timer-dial-secondary-font-size: 1.02rem;
+    --tea-timer-dial-primary-font-size: 3.1rem;
+    --tea-timer-dial-secondary-font-size: 1.05rem;
     --mdc-theme-primary: var(--primary-color, #1f2933);
     --mdc-theme-on-primary: var(
       --text-on-primary-color,
@@ -588,16 +588,16 @@ export const cardStyles = css`
   @media (max-width: 420px) {
     :host {
       --tea-timer-dial-size: 220px;
-      --tea-timer-dial-primary-font-size: 2.45rem;
-      --tea-timer-dial-secondary-font-size: 1rem;
+      --tea-timer-dial-primary-font-size: 2.9rem;
+      --tea-timer-dial-secondary-font-size: 1.02rem;
     }
   }
 
   @media (min-width: 520px) {
     :host {
       --tea-timer-dial-size: 236px;
-      --tea-timer-dial-primary-font-size: 2.7rem;
-      --tea-timer-dial-secondary-font-size: 1.06rem;
+      --tea-timer-dial-primary-font-size: 3.3rem;
+      --tea-timer-dial-secondary-font-size: 1.1rem;
     }
   }
 `;


### PR DESCRIPTION
This branch improves countdown readability and fixes `Done`/finished-state behavior on problematic Android WebView devices.

### What changed
- Increased in-dial countdown typography for better distance readability.
- Added responsive in-dial text scaling tied to dial shrink, while preserving full-size text at full dial size.
- Hid the dial handle in `finished` (`Done`) state for visual consistency.
- Hardened finished-state fallback logic by using both monotonic-time and wall-clock projections when inferring near-zero running → idle transitions.
  - This prevents skipping/shortening the 5-second `Done` overlay on devices where monotonic timing lags or stalls.

### Tests updated
- Added regression coverage for WebView-like monotonic lag fallback in `src/state/TimerStateController.test.ts`.
- Added regression coverage for hidden handle in finished state in `src/dial/TeaTimerDial.test.ts`.
