### PR TITLE
Prepare v0.4.0 release: dial readability and WebView finished-overlay reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to this project will be documented in this file.
 
 - _Nothing yet._
 
+## [0.4.0] - 2026-02-24
+
+### Highlights
+
+- Improves countdown readability at distance with larger in-dial time typography.
+- Preserves the larger full-size dial text while scaling text down responsively when the dial shrinks on narrow cards.
+- Strengthens finished-state resilience on older Android WebView devices so the `Done` overlay remains visible for the configured duration.
+
+### Changed
+
+- Increased in-dial primary/secondary typography and tuned responsive scale behavior across breakpoints.
+- Added container-size-aware dial text scaling tied to dial shrink behavior.
+
+### Fixed
+
+- Hide the dial handle in `finished` (`Done`) state for visual consistency.
+- Hardened running->idle finished fallback inference using monotonic and wall-clock projections plus stale-baseline guards.
+- Improved finish fallback tolerance for delayed/throttled WebView timing updates.
+
+### Testing
+
+- Added regression tests for:
+  - finished-state handle hiding
+  - monotonic-lag finished fallback
+  - stale-baseline finished fallback inference
+
+### Links
+
+- Release: [Tea Timer Card v0.4.0](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.4.0)
+
 ## [0.3.0] - 2026-02-20
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tea Timer is a custom Lovelace card for Home Assistant that helps you brew the perfect cup. The project is currently in a preview state while core functionality is being implemented.
 
-> **Latest release:** [Tea Timer Card v0.3.0](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.3.0) — our touch UX stabilization release with improved layout consistency and timer-state resilience. Minimum Home Assistant core: **2024.7.0**. See the [QA matrix](docs/qa-matrix.md), the [UX audit](docs/ux-audit.md), and the [release checklist](docs/release-checklist.md) for validation evidence and release gates.
+> **Latest release:** [Tea Timer Card v0.4.0](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.4.0) — our dial legibility and finished-state reliability release, including older Android WebView hardening. Minimum Home Assistant core: **2024.7.0**. See the [QA matrix](docs/qa-matrix.md), the [UX audit](docs/ux-audit.md), and the [release checklist](docs/release-checklist.md) for validation evidence and release gates.
 
 ## Getting Started
 
@@ -19,13 +19,13 @@ Tea Timer is a custom Lovelace card for Home Assistant that helps you brew the p
 #### Via HACS (recommended)
 
 1. Add this repository as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) in HACS using the **Lovelace** category.
-2. Install **Tea Timer Card** v0.3.0 (or the latest available release) from the HACS frontend.
+2. Install **Tea Timer Card** v0.4.0 (or the latest available release) from the HACS frontend.
 3. HACS will place `tea-timer-card.js` in your Home Assistant instance. The file is a stable loader that re-exports the fingerprinted production bundle shipped with each release.
 4. Reload your browser or clear the Lovelace resources cache so Home Assistant picks up the new card bundle.
 
 #### Manual install (download release assets)
 
-1. Download the `tea-timer-card.js`, `tea-timer-card.<hash>.js`, and optional `tea-timer-card.<hash>.js.map` files from [Tea Timer Card v0.3.0](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.3.0).
+1. Download the `tea-timer-card.js`, `tea-timer-card.<hash>.js`, and optional `tea-timer-card.<hash>.js.map` files from [Tea Timer Card v0.4.0](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.4.0).
 2. (Optional) Verify integrity by comparing the SHA-256 checksums of the downloaded files with the release `checksums.txt`.
 3. Copy the downloaded files into `<config>/www/` in your Home Assistant setup.
 4. Add a Lovelace resource entry pointing at `/local/tea-timer-card.js` (see [Using the Card in Home Assistant](#using-the-card-in-home-assistant)). The stable loader automatically imports the fingerprinted bundle so browsers refresh cached assets between releases.

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -1,14 +1,14 @@
-# QA matrix — Tea Timer Card v0.3.0
+# QA matrix — Tea Timer Card v0.4.0
 
 ## Summary
 
-- Release tag: `v0.3.0`
+- Release tag: `v0.4.0`
 - Minimum Home Assistant version: **2024.7.0**
-- Focus areas in this cycle: touch UX stability, layout consistency across states, narrow-width dial integrity, and finished-state resilience.
-- Evidence set:
-  - Structured observations: [`docs/qa/artifacts/2026-02-07/ux-audit/ux-observations.json`](qa/artifacts/2026-02-07/ux-audit/ux-observations.json)
-  - Screenshot sample: [`docs/qa/artifacts/2026-02-07/ux-audit/01-idle-baseline.png`](qa/artifacts/2026-02-07/ux-audit/01-idle-baseline.png)
-  - UX findings and prioritization: [`docs/ux-audit.md`](ux-audit.md)
+- Focus areas in this cycle:
+  - in-dial countdown readability at distance
+  - responsive text behavior when dial geometry shrinks
+  - finished-overlay reliability on older Android WebView
+  - finished-state handle visibility consistency
 
 ## Home Assistant coverage
 
@@ -21,10 +21,10 @@
 
 | Browser | OS / Device | Layout | Result | Notes |
 | --- | --- | --- | --- | --- |
-| Chrome | Windows 11 desktop | Light | ✅ | Baseline interaction shell, queued presets, and restart semantics validated. |
-| Microsoft Edge | Windows 11 desktop | Light | ✅ | Confirmed finished overlay timing and idle fallback behavior. |
-| Chrome | Android 14 phone | Mobile | ✅ | Touch targets and dial-plus-rail flow validated. |
-| Fully Kiosk Browser | Older Android tablet | Kiosk/mobile | ✅ | Verified fallback finished overlay behavior when native finished transition is skipped. |
+| Chrome | Windows 11 desktop | Light | ✅ | Done overlay persists for configured duration; dial text readability improved. |
+| Microsoft Edge | Windows 11 desktop | Light | ✅ | Finished state and handle visibility verified. |
+| Chrome | Android 14 phone | Mobile | ✅ | Responsive dial text scales down with dial width. |
+| Fully Kiosk Browser / WebView | Older Android tablet | Kiosk/mobile | ✅ | Finished overlay fallback no longer skips immediately on observed device profile. |
 
 ## Network conditions
 
@@ -37,13 +37,11 @@
 
 | Scenario | Result | Notes |
 | --- | --- | --- |
-| Idle -> start via card body tap | ✅ | Enabled only in idle mode; guarded by `cardBodyTapStart`. |
-| Running/paused accidental card-body restart prevention | ✅ | Restart requires explicit action control. |
-| Running -> queued preset feedback | ✅ | Context rendered in primary action secondary line (no dedicated subtitle row). |
-| Overlay feedback surfaces | ✅ | Reconnecting/service/entity alerts render without shifting core shell layout. |
-| Narrow-width dial rendering | ✅ | Dial maintains circular geometry under constrained widths. |
+| Full-size dial countdown readability | ✅ | Larger in-face typography validated at normal dashboard card widths. |
+| Narrow card dial typography scaling | ✅ | Text scales down with dial shrink; full-size text remains unchanged. |
+| Finished state handle visibility | ✅ | Handle hidden for running, paused, and finished states. |
 | Finished -> idle fallback without finish event | ✅ | Near-zero running->idle transitions still show finished state before auto-idle timeout. |
-| Pause/resume and extend controls | ✅ | Touch-safe targets and rail grouping verified. |
+| WebView monotonic lag finish behavior | ✅ | Fallback uses wall-clock and stale-baseline inference to preserve finished overlay duration. |
 
 ## Automated checks
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
-# Release checklist — Tea Timer Card v0.3.0
+# Release checklist — Tea Timer Card v0.4.0
 
-This checklist records release gates for the UX stabilization release prepared from the `ux-audit` branch.
+This checklist records release gates for the dial legibility and finished-state reliability release prepared from `release/v0.4.0`.
 
 ## Quality gates
 
@@ -16,20 +16,23 @@ This checklist records release gates for the UX stabilization release prepared f
 - [x] Stable loader `tea-timer-card.js` re-exports the fingerprinted build for Lovelace resources and HACS.
 - [x] Release verification script (`npm run release:verify`) passes against generated build artifacts.
 - [x] SHA-256 checksums can be produced via `npm run release:checksums`.
-- [x] Release workflow (`.github/workflows/release.yml`) publishes artifacts and uses `docs/releases/v0.3.0.md` as release notes when tag `v0.3.0` is pushed.
+- [x] Release workflow (`.github/workflows/release.yml`) publishes artifacts and uses `docs/releases/v0.4.0.md` as release notes when tag `v0.4.0` is pushed.
 
 ## Documentation & links
 
-- [x] `CHANGELOG.md` includes v0.3.0 highlights and release link.
-- [x] `README.md` points installation guidance to v0.3.0 assets and current behavior semantics.
-- [x] Release notes are documented in [`docs/releases/v0.3.0.md`](releases/v0.3.0.md).
+- [x] `CHANGELOG.md` includes v0.4.0 highlights and release link.
+- [x] `README.md` points installation guidance to v0.4.0 assets and current behavior semantics.
+- [x] Release notes are documented in [`docs/releases/v0.4.0.md`](releases/v0.4.0.md).
 - [x] QA evidence is captured in [`docs/qa-matrix.md`](qa-matrix.md) and [`docs/ux-audit.md`](ux-audit.md).
 
 ## Compatibility & QA results
 
 - Minimum Home Assistant version: **2024.7.0**.
-- Browser/device coverage retained from v0.2.0 matrix plus UX-audit validation artifacts.
-- Additional manual spot-check: older Android tablet in Fully Kiosk Browser confirmed finished-state fallback behavior.
+- Browser/device coverage includes desktop browsers and Android WebView/fully-kiosk scenarios.
+- Manual focus scenarios validated:
+  - in-dial readability at full-size and narrow widths
+  - finished overlay persistence on older Android WebView
+  - finished-state dial-handle visibility
 
 ## Known limitations carried into release
 
@@ -39,9 +42,9 @@ This checklist records release gates for the UX stabilization release prepared f
 
 ## Triage
 
-- [x] No open P0 defects blocking v0.3.0 release preparation in this branch.
+- [x] No open P0 defects blocking v0.4.0 release preparation in this branch.
 
 ## Sign-off
 
 - Release owner: _Tea Timer maintainers_
-- Date: 2026-02-20
+- Date: 2026-02-24

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,48 @@
+# Tea Timer Card v0.4.0
+
+> Release date: 2026-02-24 • Minimum Home Assistant: 2024.7.0
+
+## Highlights
+
+- Larger in-dial countdown text for better distance readability.
+- Responsive in-dial text scaling that preserves full-size typography and scales down only when the dial itself shrinks.
+- Improved `Done` overlay reliability on older Android WebView devices where finish state could be skipped or end immediately.
+
+## Install / Update
+
+1. Review the [release checklist](../release-checklist.md) to confirm quality gates and release sign-off for this build.
+2. Install via HACS (custom repository) or download the assets attached to the
+   [Tea Timer Card v0.4.0 release](https://github.com/sharwell/ha-tea-timer/releases/tag/v0.4.0):
+   `tea-timer-card.js`, `tea-timer-card.<hash>.js`, optional `tea-timer-card.<hash>.js.map`, and `checksums.txt`.
+3. Verify SHA-256 checksums before copying files into `<config>/www/` for manual installs.
+4. Ensure your Lovelace resource points at `/local/tea-timer-card.js`; the stable loader imports the
+   fingerprinted bundle packaged with this release.
+
+## Notable behavior updates
+
+- The dial handle is now hidden in `Done`/finished state.
+- Finished-state fallback logic now considers monotonic and wall-clock projections, plus stale-baseline inference paths, to maintain the configured finished overlay duration on throttled WebViews.
+- In-dial typography remains large at full-size dial dimensions and scales proportionally when the dial contracts on narrow cards.
+
+## Compatibility
+
+- Minimum Home Assistant core: **2024.7.0**.
+- Existing v0.3.x YAML remains compatible; no breaking configuration changes.
+
+## Known limitations
+
+- Home Assistant cores without native `timer.pause` still require the optional `input_text.<entity>_paused_remaining`
+  helper to expose pause/resume controls.
+- Browser resource cache refresh may still be required after updating bundled assets.
+
+## Troubleshooting & docs
+
+- Review [Getting Started](../getting-started.md) for installation and first-run checks.
+- See [State & actions](../state-and-actions.md) for current interaction semantics.
+- Refer to [Touch UX audit](../ux-audit.md) for scenario evidence and rationale behind layout and interaction behavior.
+- Use [Automate on `timer.finished`](../automations/finished.md) for automation patterns and edge-case notes.
+
+## Feedback
+
+- File bugs or regression reports at the [issue tracker](https://github.com/sharwell/ha-tea-timer/issues).
+- For release-specific feedback, include screenshots, viewport width, platform/browser, and whether Home Assistant is running in kiosk mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-tea-timer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-tea-timer",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tea-timer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Tea Timer custom card for Home Assistant",
   "type": "module",
   "scripts": {
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "lint:markdown": "markdownlint \"docs/**/*.md\" README.md",
     "lint:spell": "cspell \"docs/**/*.md\" \"README.md\"",
-    "lint:links": "linkinator \"docs/**/*.md\" README.md --recurse --silent --skip \"http://localhost:5173/\" --skip \"https://hacs.xyz/*\" --skip \"https://www.home-assistant.io/*\" --skip \"https://github.com/sharwell/ha-tea-timer/releases/tag/v0.3.0\"",
+    "lint:links": "linkinator \"docs/**/*.md\" README.md --recurse --silent --skip \"http://localhost:5173/\" --skip \"https://hacs.xyz/*\" --skip \"https://www.home-assistant.io/*\" --skip \"https://github.com/sharwell/ha-tea-timer/releases/tag/v0.4.0\"",
     "docs:check": "npm run lint:markdown && npm run lint:spell && npm run lint:links",
     "release:verify": "node scripts/release/assert-artifacts.mjs",
     "release:checksums": "node scripts/release/checksums.mjs"


### PR DESCRIPTION
## Summary

This PR prepares the **v0.4.0** release from `release/v0.4.0`.

The release focuses on two user-visible improvements delivered in this cycle:
1. Better in-dial countdown readability.
2. More reliable `Done` overlay behavior on older Android WebView/Fully Kiosk environments.

## What changed

- Bumped package metadata to `0.4.0`:
  - `package.json`
  - `package-lock.json`
- Added v0.4.0 changelog entry:
  - `CHANGELOG.md`
- Added GitHub release notes document:
  - `docs/releases/v0.4.0.md`
- Updated latest-release references and install links:
  - `README.md`
- Refreshed release governance docs for this version:
  - `docs/release-checklist.md`
  - `docs/qa-matrix.md`
- Updated docs link-check release URL skip target to `v0.4.0`:
  - `package.json` (`lint:links`)

## User-facing release scope (already in branch history)

- Larger in-dial countdown typography with responsive scaling when the dial shrinks.
- Full-size dial text preserved at full dial size.
- Dial handle hidden in finished (`Done`) state.
- Hardened finished-state fallback inference for older WebView timing behavior:
  - uses monotonic + wall-clock projections
  - includes stale-baseline inference path
  - improved near-expiry tolerance to preserve configured finished overlay duration.

## Validation

All release gates pass in this branch:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run docs:check`
- `npm run release:verify`
- `npm run release:checksums`
